### PR TITLE
4 add blank line after copyright string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test_venv/touchfile: test_requirements.txt
 	touch test_venv/touchfile
 
 test: test_venv
-	. test_venv/bin/activate; pytest --cov-report term-missing --cov=add_msg_issue_hook --cov=add_copyright_hook tests/add_msg_issue_hook tests/add_copyright_hook
+	. test_venv/bin/activate; pytest --cov-report term-missing --cov=add_msg_issue_hook --cov=add_copyright_hook tests/
 
 test_add_issue: test_venv
 	. test_venv/bin/activate; pytest --cov-report term-missing --cov=add_msg_issue_hook tests/add_msg_issue_hook -x

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test_venv/touchfile: test_requirements.txt
 	touch test_venv/touchfile
 
 test: test_venv
-	. test_venv/bin/activate; pytest --cov-report term-missing --cov=add_msg_issue_hook --cov=add_copyright_hook tests/
+	. test_venv/bin/activate; pytest --cov-report term-missing --cov=add_msg_issue_hook --cov=add_copyright_hook tests/add_msg_issue_hook tests/add_copyright_hook
 
 test_add_issue: test_venv
 	. test_venv/bin/activate; pytest --cov-report term-missing --cov=add_msg_issue_hook tests/add_msg_issue_hook -x

--- a/add_copyright_hook/add_copyright.py
+++ b/add_copyright_hook/add_copyright.py
@@ -34,7 +34,7 @@ def _contains_copyright_string(input: str) -> bool:
     return True
 
 
-def _is_shebang(input: str) -> bool:
+def _has_shebang(input: str) -> bool:
     return input.startswith("#!")
 
 
@@ -64,12 +64,20 @@ def _insert_copyright_string(copyright: str, content: str) -> str:
         str: The modified content, including the copyright string.
     """
     lines: list = [line for line in content.split("\n")]
-    for i, line in enumerate(lines):
-        if _is_shebang(line):
-            lines[i] += "\n"
-            continue
-        lines = lines[0:i] + [copyright] + lines[i:]
-        break
+
+    shebang: t.Optional[str] = None
+    if _has_shebang(content):
+        shebang = lines[0]
+        lines = lines[1:]
+
+    if lines[0] == "":
+        lines = [copyright] + lines
+    else:
+        lines = [copyright, ""] + lines
+
+    if shebang is not None:
+        lines = [shebang, ""] + lines
+
     return "\n".join(lines)
 
 

--- a/tests/add_copyright_hook/unit/test_add_copyright.py
+++ b/tests/add_copyright_hook/unit/test_add_copyright.py
@@ -48,12 +48,12 @@ class TestIsShebang:
     @staticmethod
     @pytest.mark.parametrize("input", ["#!/usr/bin/python"])
     def test_returns_true_for_shebang(input):
-        assert add_copyright._is_shebang(input)
+        assert add_copyright._has_shebang(input)
 
     @staticmethod
     @pytest.mark.parametrize("input", ["#/usr/bin/python"])
     def test_returns_false_for_not_shebang(input):
-        assert not add_copyright._is_shebang(input)
+        assert not add_copyright._has_shebang(input)
 
 
 class TestConstructCopyrightString:
@@ -61,9 +61,10 @@ class TestConstructCopyrightString:
     @pytest.mark.parametrize("name", ["Harold Hadrada"])
     @pytest.mark.parametrize("year", ["1066"])
     def test_correct_construction(name, year):
-        expected = f"# Copyright (c) {year} {name}"
-        print(expected)
-        assert add_copyright._construct_copyright_string(name, year) == expected
+        assert (
+            add_copyright._construct_copyright_string(name, year)
+            == f"# Copyright (c) {year} {name}"
+        )
 
 
 class TestInsertCopyrightString:
@@ -75,14 +76,14 @@ class TestInsertCopyrightString:
         ],
     )
     def test_insterts_string(content):
-        expected = "<copyright sentinel>\n" + content
+        expected = "<copyright sentinel>\n\n" + content
 
         out = add_copyright._insert_copyright_string("<copyright sentinel>", content)
 
         assert out == expected
 
     @staticmethod
-    def test_insterts_copyright_after_shebang():
+    def test_inserts_copyright_after_shebang():
         content = (
             "#!shebang\n" "\n" '"""docstring"""\n' "\n" "def some_code():\n" "    pass"
         )


### PR DESCRIPTION
Reworks the insertion of the copyright string into the content in order to ensure that it is always followed by an empty line.