### PR TITLE
6 allow external configuration of copyright info

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,6 +125,7 @@ repos:
     hooks:
       - id: mypy
         exclude: ^tests/
+        additional_dependencies: [types-all]
 
   # YAML  #############################################################################
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ repos:
     -   id: add-msg-issue
 ```
 
-The config file must specify a name and year to use. Currently supported config formats are: JSON and YAML.
+The config file can contain the name and year. Any properties that are not set by the config file will be inferred from the current year / git user name. Currently supported config formats are: JSON and YAML.
 
 
 #### 3.1.2 `.add-copyright-hook-config.yaml` file.

--- a/README.md
+++ b/README.md
@@ -78,12 +78,23 @@ where the year is the current year, and the name is sourced from the git `user.n
 
 ### 3.1 Controlling the name and year
 
+The hook looks for copyright information in the following hierarchy:
+
+1. Command-line arguments. Either specifying the name and year directly, or providing a configuration file that specifies them.
+2. A `.add-copyright-hook-config.yaml` in the root directory of the repo.
+3. The current year and git user.name
+
+#### 3.1.1 Command line arguments
+
 The `add-copyright` hook accepts the following command line arguments to control the values inserted into new copyright messages:
 
 | Flag | Description |
 |------|-------------|
 | `-n` / `--name` | Set a custom name to be used rather than git's `user.name` |
 | `-y` / `--year` | Set a custom year to be used rather than the current year. |
+| `-c` / `--config` | Specify a configuration file that contains the name and year to be used. |
+
+The name and/or year arguments cannot be used at the same time as the config argument.
 
 If you're using a `.pre-commit-config.yaml`, these can be configured as follows:
 
@@ -96,6 +107,32 @@ repos:
         args: ["-n", "James T. Kirk", "-y", "1701"]
     -   id: add-msg-issue
 ```
+
+Alternatively, a local configuration file can be specified:
+
+```yaml
+repos:
+-   repo: https://github.com/BenjaminMummery/pre-commit-hooks
+    rev: v1.0.0
+    hooks:
+    -   id: add-copyright
+        args: ["-c", "copyright-config.json"]
+    -   id: add-msg-issue
+```
+
+The config file must specify a name and year to use. Currently supported config formats are: JSON and YAML.
+
+
+#### 3.1.2 `.add-copyright-hook-config.yaml` file.
+
+If command line arguments are not specified, the hook will look for a file named `.add-copyright-hook-config.yaml` in the root of the git repo, and read the name and year from there. This file should be formatted as follows:
+
+```yaml
+name: <name sentinel>
+year: '0000'
+```
+
+
 
 ## 4. The `add-msg-issue` Hook
 

--- a/add_copyright_hook/add_copyright.py
+++ b/add_copyright_hook/add_copyright.py
@@ -93,12 +93,12 @@ def _ensure_copyright_string(file: Path, name: str, year: str) -> int:
         if _contains_copyright_string(contents):
             return 0
 
-        print(f"Fixing file `{file}`")
+        copyright_string = _construct_copyright_string(name, year)
+
+        print(f"Fixing file `{file}`: adding `{copyright_string}`")
 
         f.seek(0, 0)
-        f.write(
-            _insert_copyright_string(_construct_copyright_string(name, year), contents)
-        )
+        f.write(_insert_copyright_string(copyright_string, contents))
     return 1
 
 
@@ -145,19 +145,14 @@ def _resolve_user_name(
         str: The resolved name.
     """
     if name is not None:
-        print(f"Using cli-configured name `{name}`.")
         return name
 
     if config is not None:
         data = _read_config_file(config)
         if "name" in data:
-            print(f"Name `{data['name']}` read from config file `{config}`.")
             return data["name"]
-        print(f"Config file `{config}` has no name field.")
 
-    _name = _get_git_user_name()
-    print(f"Name `{_name}` inferred from git user.name configuration.")
-    return _name
+    return _get_git_user_name()
 
 
 def _resolve_year(year: t.Optional[str] = None, config: t.Optional[str] = None) -> str:
@@ -173,19 +168,15 @@ def _resolve_year(year: t.Optional[str] = None, config: t.Optional[str] = None) 
         str: The resolved year.
     """
     if year is not None:
-        print(f"Using cli-configured year `{year}`.")
         return year
 
     if config is not None:
         data = _read_config_file(config)
         if "year" in data:
-            print(f"Year `{data['year']}` read from config file `{config}`.")
             return data["year"]
         print(f"Config file `{config}` has no year field.")
 
-    _year = _get_current_year()
-    print(f"Year `{_year}` inferred from system clock.")
-    return _year
+    return _get_current_year()
 
 
 def _resolve_files(files: t.Union[str, t.List[str]]) -> t.List[Path]:

--- a/add_copyright_hook/add_copyright.py
+++ b/add_copyright_hook/add_copyright.py
@@ -4,12 +4,17 @@
 
 import argparse
 import datetime
+import json
 import os
 import re
+import sys
 import typing as t
 from pathlib import Path
 
+import yaml
 from git import Repo
+
+DEFAULT_CONFIG_FILE: Path = Path(".add-copyright-hook-config.yaml")
 
 
 def _contains_copyright_string(input: str) -> bool:
@@ -120,7 +125,9 @@ def _get_git_user_name() -> str:
     return name
 
 
-def _resolve_user_name(name: t.Optional[str] = None) -> str:
+def _resolve_user_name(
+    name: t.Optional[str] = None, config: t.Optional[str] = None
+) -> str:
     """Resolve the user name to attach to the copyright.
 
     If the name argument is provided, it is returned as the username. Otherwise
@@ -128,23 +135,26 @@ def _resolve_user_name(name: t.Optional[str] = None) -> str:
 
     Args:
         name (str, optional): The name argument if provided. Defaults to None.
+        config (str, optional): The config argument if provided. Defaults to None.
 
     Raises:
-        ValueError: When the name argument is not provided, and the git user
-        name is not configured.
+        ValueError: When the name argument is not provided, no config file is provided,
+        and the git user name is not configured.
 
     Returns:
         str: The resolved name.
     """
     if name is not None:
         return name
-    try:
-        return _get_git_user_name()
-    except ValueError as e:
-        raise e
+
+    if config is not None:
+        data = _read_config_file(config)
+        return data["name"]
+
+    return _get_git_user_name()
 
 
-def _resolve_year(year: t.Optional[str] = None) -> str:
+def _resolve_year(year: t.Optional[str] = None, config: t.Optional[str] = None) -> str:
     """Resolve the year to attach to the copyright.
 
     If the year argument is provided, it is returned as the year. Otherwise the
@@ -156,7 +166,14 @@ def _resolve_year(year: t.Optional[str] = None) -> str:
     Returns:
         str: The resolved year.
     """
-    return year or _get_current_year()
+    if year is not None:
+        return year
+
+    if config is not None:
+        data = _read_config_file(config)
+        return data["year"]
+
+    return _get_current_year()
 
 
 def _resolve_files(files: t.Union[str, t.List[str]]) -> t.List[Path]:
@@ -186,6 +203,20 @@ def _resolve_files(files: t.Union[str, t.List[str]]) -> t.List[Path]:
     return _files
 
 
+def _read_config_file(file_path: str) -> dict:
+    _file_path = Path(file_path)
+    data: dict
+    with open(_file_path, "r") as f:
+        if _file_path.suffix == ".json":
+            data = json.load(f)
+        elif _file_path.suffix == ".yaml":
+            data = yaml.safe_load(f)
+        else:
+            raise FileNotFoundError(f"{file_path} is not a valid config file.")
+
+    return data
+
+
 def _parse_args() -> argparse.Namespace:
     """Parse the CLI arguments.
 
@@ -197,10 +228,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("files", nargs="*", default=[])
     parser.add_argument("-n", "--name", type=str, default=None)
     parser.add_argument("-y", "--year", type=str, default=None)
+    parser.add_argument("-c", "--config", type=str, default=None)
     args = parser.parse_args()
 
-    args.name = _resolve_user_name(args.name)
-    args.year = _resolve_year(args.year)
+    if args.config and (args.name or args.year):
+        print("-c and -n|-y are mutually exclusive.")
+        sys.exit(2)
+
+    if args.config is None and os.path.isfile(DEFAULT_CONFIG_FILE):
+        args.config = DEFAULT_CONFIG_FILE
+
+    args.name = _resolve_user_name(args.name, args.config)
+    args.year = _resolve_year(args.year, args.config)
     args.files = _resolve_files(args.files)
 
     return args

--- a/add_copyright_hook/add_copyright.py
+++ b/add_copyright_hook/add_copyright.py
@@ -145,13 +145,19 @@ def _resolve_user_name(
         str: The resolved name.
     """
     if name is not None:
+        print(f"Using cli-configured name `{name}`.")
         return name
 
     if config is not None:
         data = _read_config_file(config)
-        return data["name"]
+        if "name" in data:
+            print(f"Name `{data['name']}` read from config file `{config}`.")
+            return data["name"]
+        print(f"Config file `{config}` has no name field.")
 
-    return _get_git_user_name()
+    _name = _get_git_user_name()
+    print(f"Name `{_name}` inferred from git user.name configuration.")
+    return _name
 
 
 def _resolve_year(year: t.Optional[str] = None, config: t.Optional[str] = None) -> str:
@@ -167,13 +173,19 @@ def _resolve_year(year: t.Optional[str] = None, config: t.Optional[str] = None) 
         str: The resolved year.
     """
     if year is not None:
+        print(f"Using cli-configured year `{year}`.")
         return year
 
     if config is not None:
         data = _read_config_file(config)
-        return data["year"]
+        if "year" in data:
+            print(f"Year `{data['year']}` read from config file `{config}`.")
+            return data["year"]
+        print(f"Config file `{config}` has no year field.")
 
-    return _get_current_year()
+    _year = _get_current_year()
+    print(f"Year `{_year}` inferred from system clock.")
+    return _year
 
 
 def _resolve_files(files: t.Union[str, t.List[str]]) -> t.List[Path]:
@@ -237,6 +249,7 @@ def _parse_args() -> argparse.Namespace:
 
     if args.config is None and os.path.isfile(DEFAULT_CONFIG_FILE):
         args.config = DEFAULT_CONFIG_FILE
+        print(f"Found config file `{args.config}`.")
 
     args.name = _resolve_user_name(args.name, args.config)
     args.year = _resolve_year(args.year, args.config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ packages = find:
 python_requires = >=3.5.1
 install_requires =
     gitpython >= 3.1.31
+    pyyaml >= 5.4.1
 
 [options.entry_points]
 console_scripts =

--- a/tests/add_copyright_hook/unit/test_add_copyright.py
+++ b/tests/add_copyright_hook/unit/test_add_copyright.py
@@ -226,6 +226,23 @@ class TestResolveUserName:
         mock_read_config.assert_not_called()
         mock_get_git_name.assert_called_once_with()
 
+    @staticmethod
+    def test_falls_through_if_name_missing_from_config(mocker):
+        mock_read_config = mocker.patch(
+            "add_copyright_hook.add_copyright._read_config_file",
+            return_value={},
+        )
+        mock_get_git_name = mocker.patch(
+            "add_copyright_hook.add_copyright._get_git_user_name",
+            return_value="<name sentinel>",
+        )
+
+        name = add_copyright._resolve_user_name(None, "<config file sentinel>")
+
+        assert name == "<name sentinel>"
+        mock_read_config.assert_called_once_with("<config file sentinel>")
+        mock_get_git_name.assert_called_once_with()
+
 
 class TestResolveYear:
     @staticmethod


### PR DESCRIPTION
- New command line option: -c, --config. Specifies a configuration file containing a name and/or year. These values will supersede the inferred values.
- A `.add-copyright-hook-config.yaml` file in the root directory of the repo will supersede inferred values, unless a custom config file is specified via command line options.
- Better feedback: tell the user what is being added to files!