### PR TITLE
feat: broader copyright matching

### DIFF
--- a/add_copyright_hook/add_copyright.py
+++ b/add_copyright_hook/add_copyright.py
@@ -39,7 +39,10 @@ def _contains_copyright_string(input: str) -> bool:
         bool: True if the input string is a copyright comment, false otherwise.
     """
     exp = re.compile(
-        r"^#\s?(?P<signifiers>copyright(\s?\(c\))?)\s(?P<year>\d{4})\s(?P<name>.*)",
+        r"^(?P<commentmarker>#)\s?"
+        r"(?P<signifiers>(copyright\s?|\(c\)\s?|©\s?)+)"
+        r"(?P<year>\d{4})\s"
+        r"(?P<name>.*)",
         re.IGNORECASE | re.MULTILINE,
     )
     m = re.search(exp, input)

--- a/tests/add_copyright_hook/unit/test_add_copyright.py
+++ b/tests/add_copyright_hook/unit/test_add_copyright.py
@@ -31,6 +31,8 @@ class TestContainsCopyrightString:
             "# copyright 1234 Qwe Rty",
             "# COPYRIGHT 5678 Uio Pas",
             "unconnected first line\n# Copyright 1984 Aldous Huxley",
+            "# © 9999 Obi Wan Kenobi",
+            "# Copyright © 9876 Gandalf the Grey",
         ],
     )
     def test_returns_true_for_correct_strings(input_string):


### PR DESCRIPTION
widen copyright matching to allow any combination of 'copyright', '(c)' and/or '©'