### PR TITLE
Feat: add hook to detect test tool imports outside of test files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         args: [-w]
 
   - repo: https://github.com/BenjaminMummery/pre-commit-hooks
-    rev: v2.3.2
+    rev: v2.4.0
     hooks:
       - id: add-copyright
       - id: add-msg-issue

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -69,3 +69,11 @@
   always_run: true
   stages: [commit]
   files: ^.gitignore
+- id: no-import-testtools-in-src
+  name: Detect test tool imports in src files
+  description: Detect test tool imports outside of test files.
+  entry: no-import-testtools-in-src
+  language: python
+  always_run: true
+  stages: [commit]
+  files: ^.gitignore

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -76,3 +76,4 @@
   language: python
   always_run: true
   stages: [commit]
+  types_or: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -76,4 +76,3 @@
   language: python
   always_run: true
   stages: [commit]
-  files: ^.gitignore

--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,8 @@ test_sort_file_contents: test_venv
 	@. test_venv/bin/activate; \
 	python -c "$$PRETTYPRINT_PYSCRIPT" RUNNING 'SORT_FILE_CONTENTS' TESTS; \
 	pytest tests/sort_file_contents_hook -x
+
+test_no_testtools: test_venv
+	@. test_venv/bin/activate; \
+	python -c "$$PRETTYPRINT_PYSCRIPT" RUNNING 'SORT_FILE_CONTENTS' TESTS; \
+	pytest tests/no_import_testtools_in_src_hook -x

--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,5 @@ test_sort_file_contents: test_venv
 
 test_no_testtools: test_venv
 	@. test_venv/bin/activate; \
-	python -c "$$PRETTYPRINT_PYSCRIPT" RUNNING 'SORT_FILE_CONTENTS' TESTS; \
+	python -c "$$PRETTYPRINT_PYSCRIPT" RUNNING 'NO_TESTTOOLS' TESTS; \
 	pytest tests/no_import_testtools_in_src_hook -x

--- a/README.md
+++ b/README.md
@@ -15,11 +15,27 @@ A selection of quality-of-life tools for use with [pre-commit](https://github.co
     - [1.2 Usage in a vanilla hook](#12-usage-in-a-vanilla-hook)
   - [2. Hooks](#2-hooks)
     - [2.1 The `add-copyright` Hook](#21-the-add-copyright-hook)
+      - [2.1.1 Configuration](#211-configuration)
+        - [CLI Arguments](#cli-arguments)
+        - [`.pre-commit-config.yaml` Configuration](#pre-commit-configyaml-configuration)
+        - [Config file configuration](#config-file-configuration)
+      - [2.1.2 Command line arguments](#212-command-line-arguments)
+        - [`pyproject.toml`](#pyprojecttoml)
+      - [2.1.3 `.add-copyright-hook-config.yaml` file.](#213-add-copyright-hook-configyaml-file)
+      - [2.1.4 Language Support.](#214-language-support)
     - [2.2 The `update-copyright` Hook](#22-the-update-copyright-hook)
     - [2.3 The `add-msg-issue` Hook](#23-the-add-msg-issue-hook)
+      - [2.3.1 Example 1: Usage when defining the commit msg from command line](#231-example-1-usage-when-defining-the-commit-msg-from-command-line)
+      - [2.3.2 Example 2: Usage when defining the commit msg from editor](#232-example-2-usage-when-defining-the-commit-msg-from-editor)
+      - [2.3.3 Defining a custom template](#233-defining-a-custom-template)
     - [2.4 The `sort-file-contents` hook](#24-the-sort-file-contents-hook)
+      - [2.4.1 Section - aware sorting](#241-section---aware-sorting)
+      - [2.4.2 Uniqueness](#242-uniqueness)
+    - [2.5 The `no-import-testtools-in-src` hook](#25-the-no-import-testtools-in-src-hook)
   - [3. Development](#3-development)
     - [3.1 Testing](#31-testing)
+      - [3.1.1 Testing scheme](#311-testing-scheme)
+      - [3.1.2 Running Tests](#312-running-tests)
 
 <!--TOC-->
 
@@ -37,9 +53,11 @@ repos:
     rev: v1.0.0
     hooks:
     -   id: add-copyright
+    -   id: update-copyright
     -   id: add-msg-issue
     -   id: sort-file-contents
         files: .gitignore
+    -   id: no-import-testtools-in-src
 ```
 
 Even if you've already installed pre-commit, it may be necessary to run:
@@ -312,6 +330,10 @@ The `-u` or `--unique` flag causes the hook to check the sorted lines for unique
 Duplicate entries within the same section will be removed automatically;
 lines that are duplicated between sections will be left in place and a warning raised to the user.
 This latter behaviour is due to us not knowing which section the line should belong to.
+
+### 2.5 The `no-import-testtools-in-src` hook
+
+This hook checks for imports of `pytest` and/or `unittest` in source files that are not test files (i.e. do not have 'test' somewhere in their path).
 
 ## 3. Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ no-import-testtools-in-src = "src.no_import_testtools_in_src_hook.no_import_test
 
 [project.optional-dependencies]
 dev = [
+    "path < 16",  # TODO: unpin if pytest-git > 1.7.0 handles the removal of isdir()
     "freezegun",
     "pre-commit",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ add-copyright = "src.add_copyright_hook.add_copyright:main"
 add-msg-issue = "src.add_msg_issue_hook.add_msg_issue:main"
 sort-file-contents = "src.sort_file_contents_hook.sort_file_contents:main"
 update-copyright = "src.update_copyright_hook.update_copyright:main"
+no-import-testtools-in-src = "src.no_import_testtools_in_src_hook.no_import_testtools_in_src:main"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ no-import-testtools-in-src = "src.no_import_testtools_in_src_hook.no_import_test
 
 [project.optional-dependencies]
 dev = [
-    "path < 16",  # TODO: unpin if pytest-git > 1.7.0 handles the removal of isdir()
+    "path < 16",  # TODO: (95) unpin if pytest-git > 1.7.0 handles the removal of isdir
     "freezegun",
     "pre-commit",
     "pytest",

--- a/src/no_import_testtools_in_src_hook/__init__.py
+++ b/src/no_import_testtools_in_src_hook/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Benjamin Mummery
+
+"""Pre-commit hook for detecting test-specific imports outside of test files."""

--- a/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
+++ b/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
@@ -8,6 +8,60 @@ consult the README file.
 """
 
 
+import argparse
+from pathlib import Path
+
+from src._shared import resolvers
+
+
+def _check_for_imports(file: Path) -> int:
+    """
+    Check whether the file imports from a testing toolkit.
+
+    Currently detects imports from pytest and unittest.
+
+    Args:
+        file (Path): The file to be checked
+
+    Returns:
+        int: 1 if the file imports testing, 0 otherwise.
+    """
+    bad_imports = []
+
+    with open(file) as f:
+        content: str = f.read()
+
+    if "import pytest" in content:
+        bad_imports.append("pytest")
+    if "import unittest" in content:
+        bad_imports.append("unittest")
+
+    if len(bad_imports) == 0:
+        return 0
+
+    print(f"{file} is not a test file, but imports {', '.join(bad_imports)}")
+    return 1
+
+
+def _parse_args() -> argparse.Namespace:
+    """
+    Parse the CLI arguments.
+
+    Returns:
+        argparse.Namespace with the following attributes:
+        - files (list of Path): the paths to each changed file relevant to this hook.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*", default=[])
+
+    args = parser.parse_args()
+
+    # Check that files exist
+    args.files = resolvers.resolve_files(args.files)
+
+    return args
+
+
 def main():
     """
     Entrypoint for the no_import_testtools_in_src hook.
@@ -18,11 +72,11 @@ def main():
     Returns:
         int: 1 if imports are found, 0 otherwise.
     """
-    # files = _parse_args().files
+    files = _parse_args().files
 
     retv: int = 0
-    # for file in files:
-    #     retv |= _check_for_imports(file)
+    for file in files:
+        retv |= _check_for_imports(file)
 
     return retv
 

--- a/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
+++ b/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
@@ -72,7 +72,7 @@ def main():
     Returns:
         int: 1 if imports are found, 0 otherwise.
     """
-    files = _parse_args().files
+    files = [file for file in _parse_args().files if "test" not in str(file)]
 
     retv: int = 0
     for file in files:

--- a/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
+++ b/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
@@ -31,10 +31,9 @@ def _check_for_imports(file: Path) -> int:
     with open(file) as f:
         content: str = f.read()
 
-    if "import pytest" in content:
-        bad_imports.append("pytest")
-    if "import unittest" in content:
-        bad_imports.append("unittest")
+    for test_toolkit in ["pytest", "unittest"]:
+        if f"import {test_toolkit}" in content:
+            bad_imports.append(test_toolkit)
 
     if len(bad_imports) == 0:
         return 0

--- a/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
+++ b/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Benjamin Mummery
+
+"""
+Scan source files that aren't tests for test-specific imports (pytest, unittest, etc).
+
+This module is intended for use as a pre-commit hook. For more information please
+consult the README file.
+"""
+
+
+def main():
+    """
+    Entrypoint for the no_import_testtools_in_src hook.
+
+    Scan source files that aren't tests for test-specific imports (pytest, unittest,
+    etc).
+
+    Returns:
+        int: 1 if imports are found, 0 otherwise.
+    """
+    # files = _parse_args().files
+
+    retv: int = 0
+    # for file in files:
+    #     retv |= _check_for_imports(file)
+
+    return retv
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tests/add_copyright_hook/test_system_add_copyright.py
+++ b/tests/add_copyright_hook/test_system_add_copyright.py
@@ -29,7 +29,7 @@ class TestNoChanges:
                 COMMAND, capture_output=True, text=True
             )
 
-        assert process.returncode == 1, process.stdout + process.stderr
+        assert process.returncode == 0, process.stdout + process.stderr
         assert "Add copyright string to source files" in process.stdout
         assert "Passed" in process.stdout
 

--- a/tests/add_copyright_hook/test_system_add_copyright.py
+++ b/tests/add_copyright_hook/test_system_add_copyright.py
@@ -29,7 +29,7 @@ class TestNoChanges:
                 COMMAND, capture_output=True, text=True
             )
 
-        assert process.returncode == 0, process.stdout
+        assert process.returncode == 1, process.stdout + process.stderr
         assert "Add copyright string to source files" in process.stdout
         assert "Passed" in process.stdout
 
@@ -50,7 +50,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         for file in files:
             with open(git_repo.workspace / file, "r") as f:
                 content = f.read()
@@ -90,7 +90,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         with open(git_repo.workspace / file, "r") as f:
             output_content = f.read()
         assert_matching(
@@ -133,7 +133,7 @@ class TestDefaultBehaviour:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
 
             for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                 file = "hello" + language.extension
@@ -183,7 +183,7 @@ class TestDefaultBehaviour:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                 file = "hello" + language.extension
                 copyright_string = language.comment_format.format(
@@ -233,7 +233,7 @@ class TestDefaultBehaviour:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                 file = "hello" + language.extension
                 copyright_string = language.comment_format.format(
@@ -302,7 +302,7 @@ class TestCustomBehaviour:
                     )
 
                 # THEN
-                assert process.returncode == 1
+                assert process.returncode == 1, process.stdout + process.stderr
                 for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                     file = "hello" + language.extension
                     copyright_string = language.comment_format.format(
@@ -364,7 +364,7 @@ class TestCustomBehaviour:
                     )
 
                 # THEN
-                assert process.returncode == 1
+                assert process.returncode == 1, process.stdout + process.stderr
                 for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                     file = "hello" + language.extension
                     copyright_string = language.comment_format.format(
@@ -414,7 +414,7 @@ class TestCustomBehaviour:
                     )
 
                 # THEN
-                assert process.returncode == 1
+                assert process.returncode == 1, process.stdout + process.stderr
                 for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                     file = "hello" + language.extension
                     copyright_string = (
@@ -463,7 +463,7 @@ class TestCustomBehaviour:
                     )
 
                 # THEN
-                assert process.returncode == 1
+                assert process.returncode == 1, process.stdout + process.stderr
                 for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                     file = "hello" + language.extension
                     copyright_string = language.comment_format.format(
@@ -513,7 +513,7 @@ class TestFailureStates:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             expected_stdout = (
                 'KeyError: "Unsupported option in config file '
                 + (str(Path("/private")) if "/private" in process.stdout else "")
@@ -557,7 +557,7 @@ class TestFailureStates:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             expected_error_string: str = (
                 'KeyError: "Unsupported option in config file '
                 + (str(Path("/private")) if "/private" in process.stdout else "")
@@ -599,7 +599,7 @@ class TestFailureStates:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             expected_stdout = f"KeyError: \"The format string '{input_format}' is missing the following required keys: ['{missing_keys}']\""  # noqa: E501
             print("E:", expected_stdout)
             print("R:", process.stdout)
@@ -636,7 +636,7 @@ class TestFailureStates:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             assert error_message in process.stdout
 
         @staticmethod
@@ -663,7 +663,7 @@ class TestFailureStates:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             assert (
                 "src._shared.exceptions.InvalidConfigError: Could not parse config file "  # noqa: E501
                 in process.stdout
@@ -691,5 +691,5 @@ class TestFailureStates:
                 )
 
             # THEN
-            assert process.returncode == 1
+            assert process.returncode == 1, process.stdout + process.stderr
             assert "ValueError: Found multiple copyright strings: " in process.stdout

--- a/tests/no_import_testtools_in_src_hook/test_integration_no_import_testtools.py
+++ b/tests/no_import_testtools_in_src_hook/test_integration_no_import_testtools.py
@@ -92,6 +92,38 @@ class TestNoChanges:
         assert_matching("captured stdout", "expected stdout", captured.out, "")
         assert_matching("captured stderr", "expected stderr", captured.err, "")
 
+    @staticmethod
+    def test_changed_files_are_tests(
+        capsys: pytest.CaptureFixture,
+        mocker: MockerFixture,
+        git_repo: GitRepo,
+        cwd,
+    ):
+        # GIVEN
+        add_changed_files(
+            file := "test_hello.py",
+            file_content := "import pytest\nimport unittest\n",
+            git_repo,
+            mocker,
+        )
+
+        # WHEN
+        with cwd(git_repo.workspace):
+            assert no_import_testtools_in_src.main() == 0
+
+        # THEN
+        # Gather actual outputs
+        with open(git_repo.workspace / file, "r") as f:
+            output_content = f.read()
+        captured = capsys.readouterr()
+
+        # Compare
+        assert_matching(
+            "output content", "expected content", output_content, file_content
+        )
+        assert_matching("captured stdout", "expected stdout", captured.out, "")
+        assert_matching("captured stderr", "expected stderr", captured.err, "")
+
 
 class TestDetection:
     """In detection mode, the hook should list the problems, but shouldn't change the

--- a/tests/no_import_testtools_in_src_hook/test_integration_no_import_testtools.py
+++ b/tests/no_import_testtools_in_src_hook/test_integration_no_import_testtools.py
@@ -27,16 +27,25 @@ class TestNoChanges:
         assert_matching("captured stderr", "expected stderr", captured.err, "")
 
     @staticmethod
+    @pytest.mark.parametrize(
+        "file_content",
+        [
+            "import numpy",
+            "import numpy\nimport pydantic",
+            "import numpy\n# import pytest\nimport pydantic",
+        ],
+    )
     def test_changed_files_dont_import_testtools(
         capsys: pytest.CaptureFixture,
         mocker: MockerFixture,
         git_repo: GitRepo,
         cwd,
+        file_content: str,
     ):
         # GIVEN
         add_changed_files(
             file := "hello.py",
-            file_content := "import numpy\nimport pydantic\n",
+            file_content,
             git_repo,
             mocker,
         )

--- a/tests/no_import_testtools_in_src_hook/test_integration_no_import_testtools.py
+++ b/tests/no_import_testtools_in_src_hook/test_integration_no_import_testtools.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2024 Benjamin Mummery
+
+import pytest
+from pytest_git import GitRepo
+from pytest_mock import MockerFixture
+
+from conftest import add_changed_files, assert_matching
+from src.no_import_testtools_in_src_hook import no_import_testtools_in_src
+
+
+@pytest.mark.usefixtures("git_repo")
+class TestNoChanges:
+    @staticmethod
+    def test_no_files_changed(
+        capsys: pytest.CaptureFixture,
+        mocker: MockerFixture,
+    ):
+        # GIVEN
+        mocker.patch("sys.argv", ["stub_name"])
+
+        # WHEN
+        assert no_import_testtools_in_src.main() == 0
+
+        # THEN
+        captured = capsys.readouterr()
+        assert_matching("captured stdout", "expected stdout", captured.out, "")
+        assert_matching("captured stderr", "expected stderr", captured.err, "")
+
+    @staticmethod
+    def test_changed_files_dont_import_testtools(
+        capsys: pytest.CaptureFixture,
+        mocker: MockerFixture,
+        git_repo: GitRepo,
+        cwd,
+    ):
+        # GIVEN
+        add_changed_files(
+            file := "hello.py",
+            file_content := "import numpy\nimport pydantic\n",
+            git_repo,
+            mocker,
+        )
+
+        # WHEN
+        with cwd(git_repo.workspace):
+            assert no_import_testtools_in_src.main() == 0
+
+        # THEN
+        # Gather actual outputs
+        with open(git_repo.workspace / file, "r") as f:
+            output_content = f.read()
+        captured = capsys.readouterr()
+
+        # Compare
+        assert_matching(
+            "output content", "expected content", output_content, file_content
+        )
+        assert_matching("captured stdout", "expected stdout", captured.out, "")
+        assert_matching("captured stderr", "expected stderr", captured.err, "")
+
+    @staticmethod
+    def test_no_supported_changed_files(
+        capsys: pytest.CaptureFixture,
+        mocker: MockerFixture,
+        git_repo: GitRepo,
+        cwd,
+    ):
+        #
+        files = ["hello.txt", ".gitignore", "test.yaml"]
+        for file in files:
+            add_changed_files(
+                file,
+                file_content := "import numpy\nimport pydantic\n",
+                git_repo,
+                mocker,
+            )
+
+        # WHEN
+        with cwd(git_repo.workspace):
+            assert no_import_testtools_in_src.main() == 0
+
+        # THEN
+        # Gather actual outputs
+        with open(git_repo.workspace / file, "r") as f:
+            output_content = f.read()
+        captured = capsys.readouterr()
+
+        # Compare
+        assert_matching(
+            "output content", "expected content", output_content, file_content
+        )
+        assert_matching("captured stdout", "expected stdout", captured.out, "")
+        assert_matching("captured stderr", "expected stderr", captured.err, "")

--- a/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
+++ b/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
@@ -18,7 +18,7 @@ class TestNoChanges:
                 COMMAND, capture_output=True, text=True
             )
 
-        assert process.returncode == 0, process.stdout
+        assert process.returncode == 0, process.stdout + process.stderr
         assert "Detect test tool imports in src files" in process.stdout
         assert "Passed" in process.stdout
 
@@ -38,7 +38,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         with open(f, "r") as file:
             content = file.read()
         assert content == "<file content sentinel>"
@@ -63,7 +63,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         for file in files:
             with open(git_repo.workspace / file, "r") as f:
                 content = f.read()
@@ -88,7 +88,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         with open(git_repo.workspace / file, "r") as f:
             content = f.read()
         assert content == f"<file {file} content sentinel>"

--- a/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
+++ b/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
@@ -71,3 +71,27 @@ class TestNoChanges:
         assert "Detect test tool imports in src files" in process.stdout
         assert "Passed" in process.stdout, process.stdout
         assert "Passed" in process.stdout, process.stdout
+
+    @staticmethod
+    def test_changed_files_are_tests(git_repo: GitRepo, cwd):
+        """Files have been changed, but only test files."""
+        # GIVEN
+        file = "test_hello.py"
+        f = git_repo.workspace / file
+        f.write_text(f"<file {file} content sentinel>")
+        git_repo.run(f"git add {file}")
+
+        # WHEN
+        with cwd(git_repo.workspace):
+            process: subprocess.CompletedProcess = subprocess.run(
+                COMMAND, capture_output=True, text=True
+            )
+
+        # THEN
+        assert process.returncode == 0
+        with open(git_repo.workspace / file, "r") as f:
+            content = f.read()
+        assert content == f"<file {file} content sentinel>"
+        assert "Detect test tool imports in src files" in process.stdout
+        assert "Passed" in process.stdout, process.stdout
+        assert "Passed" in process.stdout, process.stdout

--- a/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
+++ b/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Benjamin Mummery
+
+import os
+import subprocess
+
+from pytest_git import GitRepo
+
+COMMAND = ["pre-commit", "try-repo", f"{os.getcwd()}", "no-import-testtools-in-src"]
+
+
+class TestNoChanges:
+
+    @staticmethod
+    def test_no_files_changed(git_repo: GitRepo, cwd):
+        """No files have been changed, nothing to check."""
+        with cwd(git_repo.workspace):
+            process: subprocess.CompletedProcess = subprocess.run(
+                COMMAND, capture_output=True, text=True
+            )
+
+        assert process.returncode == 0, process.stdout
+        assert "Detect test tool imports in src files" in process.stdout
+        assert "Passed" in process.stdout

--- a/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
+++ b/tests/no_import_testtools_in_src_hook/test_system_no_import_testtools.py
@@ -21,3 +21,53 @@ class TestNoChanges:
         assert process.returncode == 0, process.stdout
         assert "Detect test tool imports in src files" in process.stdout
         assert "Passed" in process.stdout
+
+    @staticmethod
+    def test_changed_files_dont_import_testtools(git_repo: GitRepo, cwd):
+        """Files have been changed, but none of them are in languages we support."""
+        # GIVEN
+
+        f = git_repo.workspace / "file.py"
+        f.write_text("<file content sentinel>")
+        git_repo.run("git add file.py")
+
+        # WHEN
+        with cwd(git_repo.workspace):
+            process: subprocess.CompletedProcess = subprocess.run(
+                COMMAND, capture_output=True, text=True
+            )
+
+        # THEN
+        assert process.returncode == 0
+        with open(f, "r") as file:
+            content = file.read()
+        assert content == "<file content sentinel>"
+        assert "Detect test tool imports in src files" in process.stdout
+        assert "Passed" in process.stdout, process.stdout
+        assert "Passed" in process.stdout, process.stdout
+
+    @staticmethod
+    def test_no_supported_files_changed(git_repo: GitRepo, cwd):
+        """Files have been changed, but none of them are in languages we support."""
+        # GIVEN
+        files = ["hello.txt", ".gitignore", "test.yaml"]
+        for file in files:
+            f = git_repo.workspace / file
+            f.write_text(f"<file {file} content sentinel>")
+            git_repo.run(f"git add {file}")
+
+        # WHEN
+        with cwd(git_repo.workspace):
+            process: subprocess.CompletedProcess = subprocess.run(
+                COMMAND, capture_output=True, text=True
+            )
+
+        # THEN
+        assert process.returncode == 0
+        for file in files:
+            with open(git_repo.workspace / file, "r") as f:
+                content = f.read()
+            assert content == f"<file {file} content sentinel>"
+        assert "Detect test tool imports in src files" in process.stdout
+        assert "Passed" in process.stdout, process.stdout
+        assert "Passed" in process.stdout, process.stdout

--- a/tests/sort_file_contents_hook/test_system_sort_file_contents.py
+++ b/tests/sort_file_contents_hook/test_system_sort_file_contents.py
@@ -20,7 +20,7 @@ class TestNoChanges:
                 COMMAND, capture_output=True, text=True
             )
 
-        assert process.returncode == 0, process.stdout
+        assert process.returncode == 0, process.stdout + process.stderr
         assert "Sort gitignore sections" in process.stdout
         assert "Passed" in process.stdout
 
@@ -41,7 +41,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         for file in files:
             with open(git_repo.workspace / file, "r") as f:
                 content = f.read()
@@ -64,7 +64,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         with open(git_repo.workspace / file, "r") as f:
             content = f.read()
         assert content == file_contents
@@ -83,7 +83,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         with open(git_repo.workspace / file, "r") as f:
             content = f.read()
         assert content == ""
@@ -113,7 +113,7 @@ class TestSorting:
             )
 
         # THEN
-        assert process.returncode == 1
+        assert process.returncode == 1, process.stdout + process.stderr
         with open(git_repo.workspace / filename, "r") as f:
             content = f.read()
         assert_matching(

--- a/tests/update_copyright_hook/test_system_update_copyright.py
+++ b/tests/update_copyright_hook/test_system_update_copyright.py
@@ -27,7 +27,7 @@ class TestNoChanges:
                 COMMAND, capture_output=True, text=True
             )
 
-        assert process.returncode == 0, process.stdout
+        assert process.returncode == 0, process.stdout + process.stderr
         assert (
             "Update dates on copyright strings in source files" in process.stdout
         ), process.stdout
@@ -50,7 +50,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         for file in files:
             with open(git_repo.workspace / file, "r") as f:
                 content = f.read()
@@ -92,7 +92,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         with open(git_repo.workspace / file, "r") as f:
             output_content = f.read()
         assert_matching(
@@ -122,7 +122,7 @@ class TestNoChanges:
             )
 
         # THEN
-        assert process.returncode == 0
+        assert process.returncode == 0, process.stdout + process.stderr
         with open(git_repo.workspace / file, "r") as f:
             output_content = f.read()
         assert_matching(
@@ -166,7 +166,7 @@ class TestChanges:
             )
 
         # THEN
-        assert process.returncode == 1
+        assert process.returncode == 1, process.stdout + process.stderr
         for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
             file = "hello" + language.extension
             copyright_string = language.comment_format.format(
@@ -221,7 +221,7 @@ class TestChanges:
             )
 
         # THEN
-        assert process.returncode == 1
+        assert process.returncode == 1, process.stdout + process.stderr
         for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
             file = "hello" + language.extension
             copyright_string = language.comment_format.format(
@@ -275,5 +275,5 @@ class TestFailureStates:
             )
 
         # THEN
-        assert process.returncode == 1
+        assert process.returncode == 1, process.stdout + process.stderr
         assert error_message in process.stdout


### PR DESCRIPTION
It's common to have `pytest`/`unittest` in `dev` dependencies. If these are accidentally imported in src files, these will raise a `ModuleNotFoundError` at run time. This hook prevents such imports from being added.