### PR TITLE
fix: handle module level docstrings containing copyright markers.

### DIFF
--- a/src/_shared/comment_mapping.py
+++ b/src/_shared/comment_mapping.py
@@ -49,7 +49,7 @@ def get_comment_markers(file: Path) -> Tuple[str, Optional[str]]:
         t.Tuple[str, t.Optional[str]]: The leading and trailing comment markers.
     """
     # Try to identify the file type from the extension.
-    tags = identify.tags_from_path(file)
+    tags = identify.tags_from_path(str(file))
     for tag in tags:
         try:
             return COMMENT_MARKERS[tag]

--- a/src/_shared/copyright_parsing.py
+++ b/src/_shared/copyright_parsing.py
@@ -12,7 +12,7 @@ class ParsedCopyrightString:
 
     def __init__(
         self,
-        commentmarkers: Optional[Tuple[str, Optional[str]]],
+        comment_markers: Optional[Tuple[str, Optional[str]]],
         signifiers: str,
         start_year: int,
         end_year: int,
@@ -32,7 +32,7 @@ class ParsedCopyrightString:
             name (str): The name of the copyright holder.
             string (str): The full copyright string as it exists in the source file.
         """
-        self.commentmarkers: Tuple[str, Optional[str]] = commentmarkers
+        self.comment_markers: Optional[Tuple[str, Optional[str]]] = comment_markers
         self.signifiers: str = signifiers
         self.start_year: int = start_year
         self.end_year: int = end_year
@@ -47,7 +47,7 @@ class ParsedCopyrightString:
     def __repr__(self) -> str:
         return (
             "ParsedCopyrightString object with:\n"
-            f"- comment marker(s): {self.commentmarkers}\n"
+            f"- comment marker(s): {self.comment_markers}\n"
             f"- signifiers: {self.signifiers}\n"
             f"- start year: {self.start_year}\n"
             f"- end year: {self.end_year}\n"
@@ -90,6 +90,8 @@ def _parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
 
     # Search the input
     match = re.search(re.compile(exp, re.IGNORECASE | re.MULTILINE), input)
+
+    # Early return for no match.
     if match is None:
         return None
 
@@ -98,10 +100,10 @@ def _parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
 
     return ParsedCopyrightString(
         None,
-        matchdict["signifiers"].strip(),
+        match_dict["signifiers"].strip(),
         start_year,
         end_year,
-        matchdict["name"].strip(),
+        match_dict["name"].strip(),
         match.group().strip(),
     )
 
@@ -132,7 +134,7 @@ def _parse_copyright_string_line(
 
     # Regex string components
     leading_comment_marker_group: str = (
-        r"(?P<leadingcommentmarker>" + re.escape(comment_markers[0]) + r")"
+        r"(?P<leading_comment_marker>" + re.escape(comment_markers[0]) + r")"
     )
     copyright_signifier_group: str = r"(?P<signifiers>(copyright\s?|\(c\)\s?|©\s?)+)\s?"
     year_group: str = r"(?P<year>(\d{4}\s?-\s?\d{4}|\d{4})+)\s?"
@@ -157,7 +159,7 @@ def _parse_copyright_string_line(
     )
     # If there's a trailing comment marker, match that too
     if comment_markers[1]:
-        exp += r"(?P<trailingcommentmarker>" + re.escape(comment_markers[1]) + r")"
+        exp += r"(?P<trailing_comment_marker>" + re.escape(comment_markers[1]) + r")"
     # Mark the end of the string.
     exp += r"$"
 
@@ -166,19 +168,21 @@ def _parse_copyright_string_line(
     if match is None:
         return None
 
-    matchdict = match.groupdict()
-    start_year, end_year = _parse_years(matchdict["year"])
-    leading_comment = matchdict["leadingcommentmarker"].strip()
+    match_dict = match.groupdict()
+    start_year, end_year = _parse_years(match_dict["year"])
+    leading_comment = match_dict["leading_comment_marker"].strip()
     trailing_comment = (
-        None if not comment_markers[1] else matchdict["trailingcommentmarker"].strip()
+        None
+        if not comment_markers[1]
+        else match_dict["trailing_comment_marker"].strip()
     )
 
     return ParsedCopyrightString(
         (leading_comment, trailing_comment),
-        matchdict["signifiers"].strip(),
+        match_dict["signifiers"].strip(),
         start_year,
         end_year,
-        matchdict["name"].strip(),
+        match_dict["name"].strip(),
         match.group().strip(),
     )
 

--- a/src/_shared/copyright_parsing.py
+++ b/src/_shared/copyright_parsing.py
@@ -95,8 +95,14 @@ def _parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
     if match is None:
         return None
 
-    matchdict = match.groupdict()
-    start_year, end_year = _parse_years(matchdict["year"])
+    match_dict = match.groupdict()
+
+    # Early return for an incomplete match (i.e. we found a passing reference to copyright, not a marker.)
+    if match_dict["year"] is None:
+        return None
+
+    # Parse year information.
+    start_year, end_year = _parse_years(match_dict["year"])
 
     return ParsedCopyrightString(
         None,

--- a/src/_shared/resolvers.py
+++ b/src/_shared/resolvers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023 - 2024 Benjamin Mummery
 
 """Common resolvers that are used by multiple hooks."""
 
@@ -19,7 +19,7 @@ def resolve_files(files: t.Union[str, t.List[str]]) -> t.List[Path]:
         exist.
 
     Returns:
-        List[Path]: A list of paths coressponding to the changed files.
+        List[Path]: A list of paths corresponding to the changed files.
     """
 
     _files: t.List[Path] = [

--- a/src/add_copyright_hook/add_copyright.py
+++ b/src/add_copyright_hook/add_copyright.py
@@ -288,7 +288,7 @@ def _read_default_configuration() -> dict:
             {"name" : "my name"}
             ```
     """
-    supported_langauge_subkeys = ["format", "docstr"]
+    supported_language_subkeys = ["format", "docstr"]
     supported_toml_keys = ["name", "format"] + [
         v for v in LANGUAGE_TAGS_TOMLKEYS.values()
     ]
@@ -313,12 +313,12 @@ def _read_default_configuration() -> dict:
         # If the key is a supported language, check that the subkeys are supported.
         if key in LANGUAGE_TAGS_TOMLKEYS.values():
             for subkey in data[key]:
-                if subkey not in supported_langauge_subkeys:
+                if subkey not in supported_language_subkeys:
                     raise KeyError(
                         f"Unsupported option in config file {filepath}: "
                         f"'{key}.{subkey}'. "
                         f"Supported options for '{key}' are: "
-                        f"{supported_langauge_subkeys}."
+                        f"{supported_language_subkeys}."
                     )
 
         retv[key] = data[key]

--- a/src/add_msg_issue_hook/add_msg_issue.py
+++ b/src/add_msg_issue_hook/add_msg_issue.py
@@ -177,7 +177,7 @@ def _parse_args() -> argparse.Namespace:
         args.template.format(subject="s", body="b", issue_id="i")
     except KeyError as e:
         raise KeyError(
-            rf"Template argument '{args.template}' contained unrecognised keywords: "
+            rf"Template argument '{args.template}' contained unrecognized keywords: "
             + str(e)
             + " and cannot be used. For more information, see "
             + "https://github.com/BenjaminMummery/pre-commit-hooks"

--- a/src/sort_file_contents_hook/sort_file_contents.py
+++ b/src/sort_file_contents_hook/sort_file_contents.py
@@ -151,7 +151,7 @@ def _find_comment_clashes(lines: t.List[str]) -> t.List[str]:
     """
     lines = [line.strip(" #") for line in lines]
     duplicates = _find_duplicates(lines)
-    return [dupl[0] for dupl in duplicates]
+    return [duplicate[0] for duplicate in duplicates]
 
 
 def _sort_contents(file: Path, unique: bool = False) -> int:

--- a/src/update_copyright_hook/update_copyright.py
+++ b/src/update_copyright_hook/update_copyright.py
@@ -23,7 +23,7 @@ from src._shared.copyright_parsing import (
 
 REMOVED_COLOUR: str = "\033[91m"
 ADDED_COLOUR: str = "\033[92m"
-ENDC: str = "\033[0m"
+END_COLOUR: str = "\033[0m"
 
 
 def _update_copyright_dates(file: Path) -> int:
@@ -76,8 +76,8 @@ def _update_copyright_dates(file: Path) -> int:
         f.truncate()
         f.write(content.replace(copyright_string.string, new_copyright_string))
 
-        print(f"{REMOVED_COLOUR}  - {copyright_string.string}{ENDC}")
-        print(f"{ADDED_COLOUR}  + {new_copyright_string}{ENDC}")
+        print(f"{REMOVED_COLOUR}  - {copyright_string.string}{END_COLOUR}")
+        print(f"{ADDED_COLOUR}  + {new_copyright_string}{END_COLOUR}")
 
         return 1
 

--- a/tests/add_copyright_hook/test_integration_add_copyright.py
+++ b/tests/add_copyright_hook/test_integration_add_copyright.py
@@ -146,7 +146,7 @@ class TestNoChanges:
 @pytest.mark.parametrize(
     "git_username", ["<git config username sentinel>", "Taylor Swift"]
 )
-class TestDefaultBehaviour:
+class TestDefaultBehavior:
     class TestEmptyFiles:
         @staticmethod
         @freeze_time("1312-01-01")
@@ -194,7 +194,7 @@ class TestDefaultBehaviour:
         @staticmethod
         @freeze_time("1312-01-01")
         @pytest.mark.parametrize("config_file", ["pyproject.toml", "setup.cfg"])
-        def test_ignores_irrelevent_config_options(
+        def test_ignores_irrelevant_config_options(
             capsys: CaptureFixture,
             cwd,
             config_file: str,
@@ -401,7 +401,7 @@ class TestDefaultBehaviour:
             assert_matching("captured stderr", "expected stderr", captured.err, "")
 
 
-class TestCustomBehaviour:
+class TestCustomBehavior:
     class TestCLIArgs:
         """Test the args that can be passed to the hook via the "args" section of the
         .pre-commit-config.yaml entry.
@@ -609,7 +609,7 @@ class TestCustomBehaviour:
 
     class TestConfigFiles:
         @pytest.mark.parametrize(
-            "config_file, valformat",
+            "config_file, value_format",
             [
                 (
                     "pyproject.toml",
@@ -627,7 +627,7 @@ class TestCustomBehaviour:
             def test_custom_name_option_overrules_git_username(
                 capsys: CaptureFixture,
                 cwd,
-                valformat: str,
+                value_format: str,
                 config_file: str,
                 git_repo: GitRepo,
                 mocker: MockerFixture,
@@ -638,7 +638,7 @@ class TestCustomBehaviour:
                     git_repo.workspace,
                     config_file,
                     "[tool.add_copyright]\nname="
-                    + valformat.format(value="<config file username sentinel>")
+                    + value_format.format(value="<config file username sentinel>")
                     + "\n",
                 )
 
@@ -678,7 +678,7 @@ class TestCustomBehaviour:
             def test_custom_format_option_overrules_default_format(
                 capsys: CaptureFixture,
                 cwd,
-                valformat: str,
+                value_format: str,
                 config_file: str,
                 git_repo: GitRepo,
                 mocker: MockerFixture,
@@ -689,7 +689,7 @@ class TestCustomBehaviour:
                     git_repo.workspace,
                     config_file,
                     "[tool.add_copyright]\nformat="
-                    + valformat.format(value="(C) {name} {year}")
+                    + value_format.format(value="(C) {name} {year}")
                     + "\n",
                 )
 
@@ -968,7 +968,7 @@ class TestFailureStates:
             ):
                 # GIVEN
                 add_changed_files("hello.py", "", git_repo, mocker)
-                config_file = write_config_file(
+                config_file_path = write_config_file(
                     git_repo.workspace, config_file, config_file_content
                 )
 
@@ -981,7 +981,7 @@ class TestFailureStates:
                 expected_error_string: str = (
                     'KeyError: "Unsupported option in config file '
                     + (str(Path("/private")) if "/private" in e.exconly() else "")
-                    + f"{git_repo.workspace/ config_file}: 'unsupported_option'. "
+                    + f"{git_repo.workspace/ config_file_path}: 'unsupported_option'. "
                     "Supported options are: "
                     f'{CopyrightGlobals.SUPPORTED_TOP_LEVEL_CONFIG_OPTIONS}."'
                 )
@@ -1039,7 +1039,7 @@ class TestFailureStates:
             ):
                 # GIVEN
                 add_changed_files("hello.py", "", git_repo, mocker)
-                config_file = write_config_file(
+                config_file_path = write_config_file(
                     git_repo.workspace,
                     config_file,
                     config_file_content.format(language=language.toml_key),
@@ -1054,7 +1054,7 @@ class TestFailureStates:
                 expected_error_string: str = (
                     'KeyError: "Unsupported option in config file '
                     + (str(Path("/private")) if "/private" in e.exconly() else "")
-                    + f"{git_repo.workspace/ config_file}: "
+                    + f"{git_repo.workspace/ config_file_path}: "
                     f"'{language.toml_key}.unsupported_option'. "
                     f"Supported options for '{language.toml_key}' are: "
                     f'{CopyrightGlobals.SUPPORTED_PER_LANGUAGE_CONFIG_OPTIONS}."'
@@ -1124,7 +1124,7 @@ class TestFailureStates:
             ):
                 # GIVEN
                 add_changed_files("hello.py", "", git_repo, mocker)
-                config_file = write_config_file(
+                config_file_path = write_config_file(
                     git_repo.workspace, config_file, config_file_content
                 )
 
@@ -1137,7 +1137,7 @@ class TestFailureStates:
                 expected_error_string: str = (
                     'KeyError: "Unsupported option in config file '
                     + (str(Path("/private")) if "/private" in e.exconly() else "")
-                    + f"{git_repo.workspace/ config_file}: 'unsupported_option'. "
+                    + f"{git_repo.workspace/ config_file_path}: 'unsupported_option'. "
                     "Supported options are: "
                     f'{CopyrightGlobals.SUPPORTED_TOP_LEVEL_CONFIG_OPTIONS}."'
                 )

--- a/tests/add_copyright_hook/test_system_add_copyright.py
+++ b/tests/add_copyright_hook/test_system_add_copyright.py
@@ -104,7 +104,7 @@ class TestNoChanges:
 @pytest.mark.parametrize(
     "git_username", ["<git config username sentinel>", "Taylor Swift"]
 )
-class TestDefaultBehaviour:
+class TestDefaultBehavior:
     class TestEmptyFiles:
         @staticmethod
         def test_adding_copyright_to_empty_files(
@@ -261,7 +261,7 @@ class TestDefaultBehaviour:
                 assert expected_stdout in process.stdout
 
 
-class TestCustomBehaviour:
+class TestCustomBehavior:
     class TestConfigFiles:
         class TestGlobalConfigs:
             @staticmethod

--- a/tests/add_msg_issue_hook/test_integration_add_msg_issue.py
+++ b/tests/add_msg_issue_hook/test_integration_add_msg_issue.py
@@ -154,7 +154,7 @@ class TestAddingMessage:
         assert_matching("captured stderr", "expected stderr", captured.err, "")
 
     @staticmethod
-    def test_populated_message_file_multisection(
+    def test_populated_message_file_multi_section(
         branch_name: str,
         cwd,
         issue: str,
@@ -324,5 +324,5 @@ class TestFailureStates:
             "captured err",
             "expected_err",
             e.exconly(),
-            f"KeyError: \"Template argument {template!r} contained unrecognised keywords: '{additional_keys[0]}' and cannot be used. For more information, see https://github.com/BenjaminMummery/pre-commit-hooks\"",  # noqa: E501
+            f"KeyError: \"Template argument {template!r} contained unrecognized keywords: '{additional_keys[0]}' and cannot be used. For more information, see https://github.com/BenjaminMummery/pre-commit-hooks\"",  # noqa: E501
         )

--- a/tests/update_copyright_hook/test_integration_update_copyright.py
+++ b/tests/update_copyright_hook/test_integration_update_copyright.py
@@ -339,7 +339,7 @@ class TestChanges:
         ],
     )
     @freeze_time("1312-01-01")
-    def test_updates_multiple_date_copyrights(
+    def test_updates_multiple_date_copyright_docstrings(
         capsys: CaptureFixture,
         cwd,
         expected_copyright_string: str,


### PR DESCRIPTION
<!--- Copyright (c) 2024 Benjamin Mummery -->

## Problem Statement

A module-level docstring containing the word 'copyright' will be interpreted as a copyright marker, causing parsing to error out when it can't find a year. This is an edge case since it would have to be a module-level docstring, but one that we can fix easily.

## Checklist

- [X] The PR title follows semantic release rules (starts with one of `build`, `chore`, `ci`, `docs`, `feat`,`fix`, `perf`, `style`, `refactor`, `test`). Note that this is CASE SENSITIVE!
- [X] All commits in this PR follow semantic release rules.
