### PR TITLE
fix: default to flake8-friendly copyright notices.

### DIFF
--- a/src/add_copyright_hook/add_copyright.py
+++ b/src/add_copyright_hook/add_copyright.py
@@ -230,7 +230,7 @@ def _construct_copyright_string(
     if start_year == end_year:
         year = f"{start_year}"
     else:
-        year = f"{start_year} - {end_year}"
+        year = f"{start_year}-{end_year}"
     return f"{format.format(year=year, name=name)}"
 
 

--- a/src/update_copyright_hook/update_copyright.py
+++ b/src/update_copyright_hook/update_copyright.py
@@ -69,7 +69,7 @@ def _update_copyright_dates(file: Path) -> int:
             # single date in copyright string
             new_copyright_string = copyright_string.string.replace(
                 str(copyright_string.end_year),
-                f"{copyright_string.end_year} - {copyright_end_year}",
+                f"{copyright_string.end_year}-{copyright_end_year}",
             )
 
         f.seek(0, 0)

--- a/tests/add_copyright_hook/test_integration_add_copyright.py
+++ b/tests/add_copyright_hook/test_integration_add_copyright.py
@@ -379,7 +379,7 @@ class TestDefaultBehavior:
             # THEN
             # Construct expected outputs
             copyright_string = language.comment_format.format(
-                content=f"Copyright (c) {Globals.THIS_YEAR} - 9999 {git_username}"
+                content=f"Copyright (c) {Globals.THIS_YEAR}-9999 {git_username}"
             )
             expected_content = f"{copyright_string}\n\n<file {file} content sentinel>\n"
             expected_stdout = (

--- a/tests/update_copyright_hook/test_integration_update_copyright.py
+++ b/tests/update_copyright_hook/test_integration_update_copyright.py
@@ -161,9 +161,9 @@ class TestChanges:
     @pytest.mark.parametrize(
         "input_copyright_string, expected_copyright_string",
         [
-            ("Copyright 1066 NAME", "Copyright 1066 - 1312 NAME"),
-            ("Copyright (c) 1066 NAME", "Copyright (c) 1066 - 1312 NAME"),
-            ("(c) 1066 NAME", "(c) 1066 - 1312 NAME"),
+            ("Copyright 1066 NAME", "Copyright 1066-1312 NAME"),
+            ("Copyright (c) 1066 NAME", "Copyright (c) 1066-1312 NAME"),
+            ("(c) 1066 NAME", "(c) 1066-1312 NAME"),
         ],
     )
     @freeze_time("1312-01-01")
@@ -278,9 +278,9 @@ class TestChanges:
     @pytest.mark.parametrize(
         "input_copyright_string, expected_copyright_string",
         [
-            ("Copyright 1066 NAME", "Copyright 1066 - 1312 NAME"),
-            ("Copyright (c) 1066 NAME", "Copyright (c) 1066 - 1312 NAME"),
-            ("(c) 1066 NAME", "(c) 1066 - 1312 NAME"),
+            ("Copyright 1066 NAME", "Copyright 1066-1312 NAME"),
+            ("Copyright (c) 1066 NAME", "Copyright (c) 1066-1312 NAME"),
+            ("(c) 1066 NAME", "(c) 1066-1312 NAME"),
         ],
     )
     @freeze_time("1312-01-01")

--- a/tests/update_copyright_hook/test_system_update_copyright.py
+++ b/tests/update_copyright_hook/test_system_update_copyright.py
@@ -137,9 +137,9 @@ class TestChanges:
     @pytest.mark.parametrize(
         "input_copyright_string, expected_copyright_string",
         [
-            ("Copyright 1066 NAME", "Copyright 1066 - {year} NAME"),
-            ("Copyright (c) 1066 NAME", "Copyright (c) 1066 - {year} NAME"),
-            ("(c) 1066 NAME", "(c) 1066 - {year} NAME"),
+            ("Copyright 1066 NAME", "Copyright 1066-{year} NAME"),
+            ("Copyright (c) 1066 NAME", "Copyright (c) 1066-{year} NAME"),
+            ("(c) 1066 NAME", "(c) 1066-{year} NAME"),
         ],
     )
     def test_updates_single_date_copyrights(


### PR DESCRIPTION
<!--- Copyright (c) 2024 Benjamin Mummery -->

## Problem Statement

flake8 doesn't like whitespace in date ranges, we should default to not having them.

## Checklist

- [X] The PR title follows semantic release rules (starts with one of `build`, `chore`, `ci`, `docs`, `feat`,`fix`, `perf`, `style`, `refactor`, `test`). Note that this is CASE SENSITIVE!
- [X] All commits in this PR follow semantic release rules.
