### PR TITLE
fix: handle empty commit lists that don't raise a GitCommandError.

### DIFF
--- a/src/_shared/copyright_parsing.py
+++ b/src/_shared/copyright_parsing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024 Benjamin Mummery
+# Copyright (c) 2023 - 2025 Benjamin Mummery
 
 """Tools for parsing copyright strings."""
 
@@ -171,10 +171,17 @@ def _parse_copyright_string_line(
 
     # Search the input
     match = re.search(re.compile(exp, re.IGNORECASE | re.MULTILINE), input)
+
+    # Early return for no match
     if match is None:
         return None
 
     match_dict = match.groupdict()
+
+    # Early return for an incomplete match (i.e. we found a passing reference to copyright, not a marker.)
+    if match_dict["year"] is None:
+        return None
+
     start_year, end_year = _parse_years(match_dict["year"])
     leading_comment = match_dict["leading_comment_marker"].strip()
     trailing_comment = (


### PR DESCRIPTION
<!--- Copyright (c) 2024 Benjamin Mummery -->

## Problem Statement

## Checklist

- [x] The PR title follows semantic release rules (starts with one of `build`, `chore`, `ci`, `docs`, `feat`,`fix`, `perf`, `style`, `refactor`, `test`). Note that this is CASE SENSITIVE!
- [x] All commits in this PR follow semantic release rules.
