### PR TITLE
feat: support additional files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         args: [-w]
 
   - repo: https://github.com/BenjaminMummery/pre-commit-hooks
-    rev: v2.5.0
+    rev: v2.6.0
     hooks:
       - id: add-copyright
       - id: add-msg-issue

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -84,4 +84,5 @@
   language: python
   always_run: true
   stages: [commit]
-  types_or: [python]
+  types_or: [text]
+  exclude: .*\.lock

--- a/src/_shared/print_diff.py
+++ b/src/_shared/print_diff.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2025 Benjamin Mummery
 
-"""Utilities for printing the differences between lines with nice formatting.
-"""
+"""Utilities for printing the differences between lines with nice formatting."""
 
 from difflib import ndiff
 from typing import Union
@@ -11,7 +10,7 @@ ADDED_COLOUR: str = "\033[92m"
 END_COLOUR: str = "\033[0m"
 
 
-def print_diff(old_line: str, new_line: str, line_number: Union[int, None] = None):
+def format_diff(old_line: str, new_line: str, line_number: Union[int, None] = None):
     """Print the old and new lines, highlighting any differences between them."""
     printline_old = ""
     printline_new = ""
@@ -25,7 +24,11 @@ def print_diff(old_line: str, new_line: str, line_number: Union[int, None] = Non
         elif change.startswith("-"):
             printline_old += f"{REMOVED_COLOUR}{change[2:]}{END_COLOUR}"
 
+    output = ""
+
     if line_number is not None:
-        print(f"  line {line_number}:")
-    print(f"  - {printline_old}")
-    print(f"  + {printline_new}")
+        output += f"  line {line_number}:\n"
+    output += f"  - {printline_old}\n"
+    output += f"  + {printline_new}"
+
+    return output

--- a/src/_shared/test_print_diff.py
+++ b/src/_shared/test_print_diff.py
@@ -5,29 +5,20 @@ from conftest import assert_matching
 from . import print_diff
 
 
-def test_print_diff(capsys):
-    # WHEN
-    print_diff.print_diff("ABC", "AxxB")
-
-    # THEN
-    captured = capsys.readouterr()
+def test_print_diff():
     assert_matching(
         "output",
         "expected output",
-        captured.out,
+        print_diff.format_diff("ABC", "AxxB"),
         f"  - AB{print_diff.REMOVED_COLOUR}C{print_diff.END_COLOUR}\n  + A{print_diff.ADDED_COLOUR}x{print_diff.END_COLOUR}{print_diff.ADDED_COLOUR}x{print_diff.END_COLOUR}B",
     )
 
 
 def test_print_diff_with_line_no(capsys):
-    # WHEN
-    print_diff.print_diff("Armour", "armor", 7)
-
-    # THEN
     captured = capsys.readouterr()
     assert_matching(
         "output",
         "expected output",
-        captured.out,
+        print_diff.format_diff("Armour", "armor", 7),
         f"  line 7:\n  - {print_diff.REMOVED_COLOUR}A{print_diff.END_COLOUR}rmo{print_diff.REMOVED_COLOUR}u{print_diff.END_COLOUR}r\n  + {print_diff.ADDED_COLOUR}a{print_diff.END_COLOUR}rmor",
     )

--- a/src/americanise_hook/americanise.py
+++ b/src/americanise_hook/americanise.py
@@ -100,6 +100,8 @@ def _americanise(file: Path, dictionary: dict) -> int:
 
     new_content = old_content.split("\n")
 
+    diffs = []
+
     for line_no, line in enumerate(new_content):
         if "pragma: no americanise" in line:
             continue
@@ -113,7 +115,7 @@ def _americanise(file: Path, dictionary: dict) -> int:
                 line = line[: index[0]] + new_word + line[index[1] :]
 
         if old_line != line:
-            print_diff.print_diff(old_line, line, line_no + 1)
+            diffs.append(print_diff.format_diff(old_line, line, line_no + 1))
             new_content[line_no] = line
 
     if (output := "\n".join(new_content)) == old_content:
@@ -121,6 +123,10 @@ def _americanise(file: Path, dictionary: dict) -> int:
 
     with open(file, "w") as f:
         f.write(output)
+
+    print(file)
+    for diff in diffs:
+        print(diff)
 
     return 1
 

--- a/src/update_copyright_hook/update_copyright.py
+++ b/src/update_copyright_hook/update_copyright.py
@@ -72,7 +72,12 @@ def _update_copyright_dates(file: Path) -> int:
         f.truncate()
         f.write(content.replace(copyright_string.string, new_copyright_string))
 
-        print_diff.print_diff(copyright_string.string, new_copyright_string)
+        [
+            print(diff)
+            for diff in print_diff.format_diff(
+                copyright_string.string, new_copyright_string
+            )
+        ]
 
         return 1
 

--- a/tests/americanise_hook/test_integration_americanise.py
+++ b/tests/americanise_hook/test_integration_americanise.py
@@ -51,6 +51,7 @@ def mock_colour(mocker):
     mocker.patch("src.americanise_hook.americanise.print_diff.END_COLOUR", "")
 
 
+@pytest.mark.parametrize("extension", [".py", ".md"], ids=["python", "markdown"])
 class TestNoChanges:
     @staticmethod
     @pytest.mark.parametrize("file_content", [us_file_content, ""])
@@ -61,9 +62,10 @@ class TestNoChanges:
         cwd,
         file_content: str,
         mock_colour,
+        extension: str,
     ):
         # GIVEN
-        add_changed_files(file := "hello.py", file_content, git_repo, mocker)
+        add_changed_files(file := f"hello{extension}", file_content, git_repo, mocker)
 
         # WHEN
         with cwd(git_repo.workspace):
@@ -82,6 +84,7 @@ class TestNoChanges:
         assert_matching("captured stderr", "expected stderr", captured.err, "")
 
 
+@pytest.mark.parametrize("extension", [".py", ".md"], ids=["python", "markdown"])
 class TestDefault:
     @staticmethod
     def test_python_file_full_rename(
@@ -90,9 +93,12 @@ class TestDefault:
         git_repo: GitRepo,
         cwd,
         mock_colour,
+        extension: str,
     ):
         # GIVEN
-        add_changed_files(file := "hello.py", uk_file_content, git_repo, mocker)
+        add_changed_files(
+            file := f"hello{extension}", uk_file_content, git_repo, mocker
+        )
 
         # WHEN
         with cwd(git_repo.workspace):
@@ -112,6 +118,7 @@ class TestDefault:
             assert report in captured.out
 
 
+@pytest.mark.parametrize("extension", [".py", ".md"], ids=["python", "markdown"])
 class TestCustom:
     @staticmethod
     def test_custom_word(
@@ -120,9 +127,12 @@ class TestCustom:
         git_repo: GitRepo,
         cwd,
         mock_colour,
+        extension: str,
     ):
         # GIVEN
-        add_changed_files(file := "hello.py", "sentinel text", git_repo, mocker)
+        add_changed_files(
+            file := f"hello{extension}", "sentinel text", git_repo, mocker
+        )
         mocker.patch("sys.argv", ["stub_name", "-w", "text:toxt", file])
 
         # WHEN
@@ -153,9 +163,12 @@ class TestCustom:
         git_repo: GitRepo,
         cwd,
         mock_colour,
+        extension: str,
     ):
         # GIVEN
-        add_changed_files(file := "hello.py", "sentinel text", git_repo, mocker)
+        add_changed_files(
+            file := f"hello{extension}", "sentinel text", git_repo, mocker
+        )
         mocker.patch(
             "sys.argv",
             ["stub_name", "-w", "text:toxt", "-w", "sentinel:sontinal", file],

--- a/tests/americanise_hook/test_integration_americanise.py
+++ b/tests/americanise_hook/test_integration_americanise.py
@@ -152,7 +152,7 @@ class TestCustom:
             "captured stdout",
             "expected stdout",
             captured.out,
-            "  line 1:\n  - sentinel text\n  + sentinel toxt",
+            f"hello{extension}\n  line 1:\n  - sentinel text\n  + sentinel toxt",
         )
         assert_matching("captured stderr", "expected stderr", captured.err, "")
 
@@ -191,7 +191,7 @@ class TestCustom:
             "captured stdout",
             "expected stdout",
             captured.out,
-            "  line 1:\n  - sentinel text\n  + sontinal toxt",
+            f"hello{extension}\n  line 1:\n  - sentinel text\n  + sontinal toxt",
         )
         assert_matching("captured stderr", "expected stderr", captured.err, "")
 

--- a/tests/americanise_hook/test_system_americanise.py
+++ b/tests/americanise_hook/test_system_americanise.py
@@ -78,10 +78,10 @@ class TestNoChanges:
     def test_no_supported_files_changed(git_repo: GitRepo, cwd):
         """Files have been changed, but none of them are in languages we support."""
         # GIVEN
-        files = [".gitignore", "test.yaml"]
+        files = ["poetry.lock"]
         for file in files:
             f = git_repo.workspace / file
-            f.write_text(f"<file {file} content sentinel>")
+            f.write_text(f"<file {file} content sentinel - armour>")
             git_repo.run(f"git add {file}")
 
         # WHEN
@@ -95,7 +95,7 @@ class TestNoChanges:
         for file in files:
             with open(git_repo.workspace / file, "r") as f:
                 content = f.read()
-            assert content == f"<file {file} content sentinel>"
+            assert content == f"<file {file} content sentinel - armour>"
         assert "Correct non-US spellings" in process.stdout
         assert "Passed" in process.stdout, process.stdout
 

--- a/tests/americanise_hook/test_system_americanise.py
+++ b/tests/americanise_hook/test_system_americanise.py
@@ -7,6 +7,34 @@ from pytest_git import GitRepo
 
 COMMAND = ["pre-commit", "try-repo", f"{os.getcwd()}", "americanise"]
 
+uk_file_content = """def initialise():
+    return 3
+
+class Instantiater:
+    def __init__(self):
+        self.x = "3"
+
+ARMOUR = True
+
+CoLoUr = False
+
+x = deInitIalise()
+"""
+
+us_file_content = """def initialize():
+    return 3
+
+class Instantiator:
+    def __init__(self):
+        self.x = "3"
+
+ARMOR = True
+
+CoLoR = False
+
+x = deInitIalize()
+"""
+
 
 class TestNoChanges:
     @staticmethod
@@ -25,10 +53,10 @@ class TestNoChanges:
     def test_changed_files_dont_have_misspellings(git_repo: GitRepo, cwd):
         """Files have been changed, but none of them are in languages we support."""
         # GIVEN
-
-        f = git_repo.workspace / "file.py"
-        f.write_text("<file content sentinel>")
-        git_repo.run("git add file.py")
+        for file in ["file.py", "file.md"]:
+            f = git_repo.workspace / file
+            f.write_text("<file content sentinel>")
+            git_repo.run(f"git add {file}")
 
         # WHEN
         with cwd(git_repo.workspace):
@@ -38,8 +66,10 @@ class TestNoChanges:
 
         # THEN
         assert process.returncode == 0, process.stdout + process.stderr
-        with open(f, "r") as file:
-            content = file.read()
+        for file in ["file.py", "file.md"]:
+            f = git_repo.workspace / file
+            with open(f, "r") as file:
+                content = file.read()
         assert content == "<file content sentinel>"
         assert "Correct non-US spellings" in process.stdout
         assert "Passed" in process.stdout, process.stdout
@@ -48,7 +78,7 @@ class TestNoChanges:
     def test_no_supported_files_changed(git_repo: GitRepo, cwd):
         """Files have been changed, but none of them are in languages we support."""
         # GIVEN
-        files = ["hello.txt", ".gitignore", "test.yaml"]
+        files = [".gitignore", "test.yaml"]
         for file in files:
             f = git_repo.workspace / file
             f.write_text(f"<file {file} content sentinel>")
@@ -68,3 +98,30 @@ class TestNoChanges:
             assert content == f"<file {file} content sentinel>"
         assert "Correct non-US spellings" in process.stdout
         assert "Passed" in process.stdout, process.stdout
+
+
+class TestChanges:
+    @staticmethod
+    def test_changed_files_dont_have_misspellings(git_repo: GitRepo, cwd):
+        """Files have been changed, but none of them are in languages we support."""
+        # GIVEN
+        for file in ["file.py", "file.md", "file.txt"]:
+            f = git_repo.workspace / file
+            f.write_text(uk_file_content)
+            git_repo.run(f"git add {file}")
+
+        # WHEN
+        with cwd(git_repo.workspace):
+            process: subprocess.CompletedProcess = subprocess.run(
+                COMMAND, capture_output=True, text=True
+            )
+
+        # THEN
+        assert process.returncode == 1, process.stdout + process.stderr
+        for file in ["file.py", "file.md", "file.txt"]:
+            f = git_repo.workspace / file
+            with open(f, "r") as file:
+                content = file.read()
+            assert content == us_file_content, file
+        assert "Correct non-US spellings" in process.stdout
+        assert "Failed" in process.stdout, process.stdout


### PR DESCRIPTION
<!--- Copyright (c) 2024 Benjamin Mummery -->

## Problem Statement

- Allows `americanise` to handle additional file types. Almost anything in a text format should be checked.
- (minor) reports the name of the changed file.
- (minor) bumps the version of this module used by this module

## Checklist

- [x] The PR title follows semantic release rules (starts with one of `build`, `chore`, `ci`, `docs`, `feat`,`fix`, `perf`, `style`, `refactor`, `test`). Note that this is CASE SENSITIVE!
- [x] All commits in this PR follow semantic release rules.
