### PR TITLE
refactor: separate dictionary from source code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ A selection of quality-of-life tools for use with [pre-commit](https://github.co
       - [2.4.2 Uniqueness](#242-uniqueness)
     - [2.5 The `no-import-testtools-in-src` hook](#25-the-no-import-testtools-in-src-hook)
     - [2.6 The `americanise` hook](#26-the-americanise-hook)
-      - [Configuration](#configuration)
+      - [2.6.1 Configuration](#261-configuration)
+        - [`.pre-commit-config.yaml` Configuration](#pre-commit-configyaml-configuration-1)
+        - [Inline ignores](#inline-ignores)
   - [3. Development](#3-development)
     - [3.1 Testing](#31-testing)
       - [3.1.1 Testing scheme](#311-testing-scheme)
@@ -347,7 +349,9 @@ This hook checks for imports of `pytest` and/or `unittest` in source files that 
 
 This hook checks for common non-US spellings of english words (e.g. 'initialise' rather than 'initialize') and corrects them. The hook will try to match the case of the original word, although this may be imprecise for complex case patterns when the correct spelling of the word is a different length.
 
-#### Configuration
+#### 2.6.1 Configuration
+
+##### `.pre-commit-config.yaml` Configuration
 
 Additional words can be manually added in the `.pre-commit-config.yaml`. For example, if we want to change all instances of `absence` to `absence` and all instances of `forth` to `fourth`, the configuration would be:
 
@@ -358,6 +362,22 @@ repos:
     hooks:
     -   id: americanise
         args: ["-w absence:absence", "-w forth:fourth"]
+```
+
+##### Inline ignores
+
+Individual instances can be excluded from this hook by marking them with an inline comment reading `pragma: no americanise`. For example:
+
+```python
+def initialise():  # pragma: no americanise
+    print("initialise")
+```
+
+will be corrected to:
+
+```python
+def initialise():  # pragma: no americanise
+    print("initialize")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A selection of quality-of-life tools for use with [pre-commit](https://github.co
       - [2.6.1 Configuration](#261-configuration)
         - [`.pre-commit-config.yaml` Configuration](#pre-commit-configyaml-configuration-1)
         - [Inline ignores](#inline-ignores)
+        - [The Dictionary](#the-dictionary)
   - [3. Development](#3-development)
     - [3.1 Testing](#31-testing)
       - [3.1.1 Testing scheme](#311-testing-scheme)
@@ -380,6 +381,9 @@ def initialise():  # pragma: no americanise
     print("initialize")
 ```
 
+##### The Dictionary
+
+The default dictionary is stored in `src/americanise_hook/americanise_dictionary.py`. To add words, please open an MR on this repo.
 
 ## 3. Development
 

--- a/src/americanise_hook/americanise.py
+++ b/src/americanise_hook/americanise.py
@@ -16,52 +16,7 @@ from pathlib import Path
 from typing import Union
 
 from src._shared import print_diff, resolvers
-
-DICTIONARY = {
-    # -se -> -ize
-    "characterise": "characterize",
-    "initialise": "initialize",
-    "instantiater": "instantiator",
-    "parametrise": "parametrize",
-    "prioritise": "prioritize",
-    "specialise": "specialize",
-    "organise": "organize",
-    # -yse -> -yze
-    "analyse": "analyze",
-    "catalyse": "catalyze",
-    # -our -> -or
-    "armour": "armor",
-    "behaviour": "behavior",
-    "colour": "color",
-    "flavour": "flavor",
-    "neighbour": "neighbor",
-    # -re -> -er
-    "centre": "center",
-    "fibre": "fiber",
-    "litre": "liter",
-    # -ae, -oe -> -e
-    "amoeba": "amoebae",
-    "anaesthesia": "anesthesia",
-    "caesium": "cesium",
-    # -ce -> -se
-    "defence": "defense",
-    "practise": "practice",  # british uses "practice" as the noun and "practise" as the verb. US uses "practice" for both.
-    "licence": "license",  # british uses "licence" as the noun and "license" as the verb. US uses "license" for both.
-    # -ge -> -g
-    "ageing": "aging",
-    "acknowledgement": "acknowledgment",
-    "judgement": "judgment",
-    # -ogue -> -og
-    "analogue": "analog",
-    "dialogue": "dialog",
-    # -l -> -ll
-    "fulfil": "fulfill",
-    "enrol": "enroll",
-    "skilful": "skillful",
-    # -ll -> -l
-    "labelled": "labeled",
-    "signalling": "signaling",
-}
+from src.americanise_hook.americanise_dictionary import DICTIONARY
 
 
 def _copy_case(target_string: str, input_string: str) -> str:

--- a/src/americanise_hook/americanise_dictionary.py
+++ b/src/americanise_hook/americanise_dictionary.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 Benjamin Mummery
+
+"""The underlying dictionary for the Americanise hook.
+"""
+
+DICTIONARY = {
+    # -se -> -ize
+    "characterise": "characterize",
+    "initialise": "initialize",
+    "instantiater": "instantiator",
+    "parametrise": "parametrize",
+    "prioritise": "prioritize",
+    "specialise": "specialize",
+    "organise": "organize",
+    # -yse -> -yze
+    "analyse": "analyze",
+    "catalyse": "catalyze",
+    # -our -> -or
+    "armour": "armor",
+    "behaviour": "behavior",
+    "colour": "color",
+    "flavour": "flavor",
+    "neighbour": "neighbor",
+    # -re -> -er
+    "centre": "center",
+    "fibre": "fiber",
+    "litre": "liter",
+    # -ae, -oe -> -e
+    "amoeba": "amoebae",
+    "anaesthesia": "anesthesia",
+    "caesium": "cesium",
+    # -ce -> -se
+    "defence": "defense",
+    "practise": "practice",  # british uses "practice" as the noun and "practise" as the verb. US uses "practice" for both.
+    "licence": "license",  # british uses "licence" as the noun and "license" as the verb. US uses "license" for both.
+    # -ge -> -g
+    "ageing": "aging",
+    "acknowledgement": "acknowledgment",
+    "judgement": "judgment",
+    # -ogue -> -og
+    "analogue": "analog",
+    "dialogue": "dialog",
+    # -l -> -ll
+    "fulfil": "fulfill",
+    "enrol": "enroll",
+    "skilful": "skillful",
+    # -ll -> -l
+    "labelled": "labeled",
+    "signalling": "signaling",
+}


### PR DESCRIPTION
## Problem Statement

We want to be able to add words without it looking like functionality has changed, so it makes sense to separate the dictionary from the code.

## Checklist

- [x] The PR title follows semantic release rules (starts with one of `build`, `chore`, `ci`, `docs`, `feat`,`fix`, `perf`, `style`, `refactor`, `test`). Note that this is CASE SENSITIVE!
- [x] All commits in this PR follow semantic release rules.
