### PR TITLE
ci: skip no-commit-to-branch in ci.

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -8,7 +8,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     env:
-      SKIP: update-copyright
+      SKIP: update-copyright,no-commit-to-branch
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3


### PR DESCRIPTION
<!--- Copyright (c) 2024 Benjamin Mummery -->

## Problem Statement

We don't want `no-commit-to-branch` to run in our ci checks since we want to be able to run these on main.

## Checklist

- [x] The PR title follows semantic release rules (starts with one of `build`, `chore`, `ci`, `docs`, `feat`,`fix`, `perf`, `style`, `refactor`, `test`). Note that this is CASE SENSITIVE!
- [x] All commits in this PR follow semantic release rules.
