### PR TITLE
feat: sync docstring types

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,5 +11,10 @@ jobs:
       SKIP: update-copyright,no-commit-to-branch
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: 0.10.4
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-versions: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-versions: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v6
       - name: Install uv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+default_language_version:
+  python: python3
+
 default_install_hook_types: [pre-commit, pre-merge-commit, pre-push, prepare-commit-msg,
   commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
 default_stages: [pre-commit, pre-push]
@@ -12,152 +15,142 @@ exclude: |
   )
 
 repos:
-  # PROCEDURAL  ########################################################################
+  # Fast, read-only checks first (fail before any file modifications).
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      # Forbid comitting large files
-      - id: check-added-large-files
-        args: [--maxkb=500]
-      # Forbid names that would conflict in non-case-sensitive filesystems
-      - id: check-case-conflict
-      # Forbid merge conflict markers
-      - id: check-merge-conflict
-        args: [--assume-in-merge]
-      # Check that symlinks are up to date
-      - id: check-symlinks
-      # Check for destroyed symlinks
-      - id: destroyed-symlinks
-      # Forbid allow submodules
-      - id: forbid-submodules
-      # Don't allow committing to protected branches.
       - id: no-commit-to-branch
         args: [-b, main, -b, master, -b, dev, -b, develop]
         stages: [pre-commit]
+      - id: detect-private-key
+      - id: check-merge-conflict
+        args: [--assume-in-merge]
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
+      - id: check-ast
+      - id: check-json
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: forbid-submodules
+      - id: name-tests-test
+        args: [--pytest-test-first]
+        exclude: tests/examples/.*|conftest\.py
 
   - repo: https://github.com/pre-commit/sync-pre-commit-deps
     rev: v0.0.3
     hooks:
-      # Sync additional dependencies between hooks
       - id: sync-pre-commit-deps
 
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.8
+  # Content normalisers (before spell-check and Python lint/format).
+  - repo: local
     hooks:
-      # Require conventional commit messages
-      - id: commitizen
-
-  # GENERAL PURPOSE  ###################################################################
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      # Forbid executable files without shebangs
-      - id: check-executables-have-shebangs
-      # Forbid shebangs in non-executable files
-      - id: check-shebang-scripts-are-executable
-      # Require that vcs links are permalinks
-      - id: check-vcs-permalinks
-      # Insert blank newlines at the ends of files
-      - id: end-of-file-fixer
-      #
-      - id: fix-byte-order-marker
-      # Forbid mixed line endings
-      - id: mixed-line-ending
-      # Enforce test naming convention
-      - id: name-tests-test
-        args: [--pytest-test-first]
-        exclude: tests/examples/.*
-      # Remove trailing whitespaces at the ends of lines
-      - id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
-
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: 'v1.10.0'
-    hooks:
-      - id: text-unicode-replacement-char
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.5.0
-    hooks:
-      # Remove outdated noqa markers
-      - id: yesqa
+      - id: add-copyright
+        name: Add copyright string to source files
+        entry: uv run add-copyright
+        language: system
+        exclude: CHANGELOG.md
+        types_or:
+          - c++
+          - c#
+          - css
+          - dart
+          - html
+          - java
+          - javascript
+          - kotlin
+          - lua
+          - markdown
+          - perl
+          - php
+          - python
+          - ruby
+          - rust
+          - scala
+          - sql
+          - swift
+      - id: update-copyright
+        name: Update dates on copyright strings in source files
+        entry: uv run update-copyright
+        language: system
+        types_or:
+          - c++
+          - c#
+          - css
+          - dart
+          - html
+          - java
+          - javascript
+          - kotlin
+          - lua
+          - markdown
+          - perl
+          - php
+          - python
+          - ruby
+          - rust
+          - scala
+          - sql
+          - swift
+      - id: add-msg-issue
+        name: Add issue to the commit message
+        entry: uv run add-msg-issue
+        language: system
+        always_run: true
+        stages: [prepare-commit-msg]
+      - id: sort-file-contents
+        name: Sort gitignore sections
+        entry: uv run sort-file-contents
+        language: system
+        files: ^.gitignore
+      - id: no-import-testtools-in-src
+        name: Detect test tool imports in src files
+        entry: uv run no-import-testtools-in-src
+        language: system
+        types_or: [python]
+      - id: sync-type-hints
+        name: Sync type hints with docstrings
+        entry: uv run sync-type-hints
+        language: system
+        files: ^src/
+        exclude: src/.*/test_.*\.py$
+        args: [--on-clash=prefer-signature]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
-      # Spellchecking
       - id: codespell
         args: [-w]
 
-  - repo: https://github.com/BenjaminMummery/pre-commit-hooks
-    rev: v2.8.0
+  # Python lint/format (ruff replaces isort, pycln, pydocstyle, interrogate, pyupgrade).
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.2
     hooks:
-      # Add a copyright notice to files that don't have one
-      - id: add-copyright
-        exclude: CHANGELOG.md
-      # Append jira issue from the branch name to the commit
-      - id: add-msg-issue
-      # Update existing copyright markers.
-      - id: update-copyright
-      # Sort the .gitignore file (respects sections)
-      - id: sort-file-contents
-        files: .gitignore
+      - id: ruff-check
+        args: [--config=pyproject.toml, --fix]
+      - id: ruff-format
+        args: [--config=pyproject.toml]
 
-  # SECURITY  ##########################################################################
+  # Whitespace and line-ending cleanup after formatters.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      - id: detect-private-key
-
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
-    hooks:
-      - id: gitleaks
-
-  - repo: https://github.com/thoughtworks/talisman
-    rev: 'v1.37.0'
-    hooks:
-      - id: talisman-push
-      - id: talisman-commit
-
-  # CONFIGURATION  #####################################################################
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v3.2.0
-    hooks:
-      - id: setup-cfg-fmt
-
-  # C++ ###############################################################################
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v21.1.8'
-    hooks:
-      - id: clang-format
-
-  # CMAKE  ############################################################################
-  - repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: v0.6.13
-    hooks:
-      - id: cmake-format
-      - id: cmake-lint
-
-  # MARKDOWN  #########################################################################
-  - repo: https://github.com/thlorenz/doctoc
-    rev: 'v2.3.0'
-    hooks:
-      - id: doctoc
-
-  # PYTHON  ###########################################################################
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-ast
-      - id: check-builtin-literals
-      - id: check-docstring-first
-        exclude: tests/examples/.*
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
       - id: debug-statements
-      - id: requirements-txt-fixer
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: 'v1.10.0'
+    rev: v1.10.0
     hooks:
       - id: python-use-type-annotations
       - id: python-check-blanket-noqa
@@ -165,143 +158,34 @@ repos:
       - id: python-check-mock-methods
       - id: python-no-eval
       - id: python-no-log-warn
-      - id: python-use-type-annotations
+      - id: text-unicode-replacement-char
 
-  - repo: https://github.com/asottile/add-trailing-comma
-    rev: v4.0.0
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.5.0
     hooks:
-      - id: add-trailing-comma
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.6.0
-    hooks:
-      - id: pycln
-        exclude: __init__.py
-
-  - repo: https://github.com/dannysepler/rm_unneeded_f_str
-    rev: v0.2.0
-    hooks:
-      - id: rm-unneeded-f-str
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
-    hooks:
-      - id: ruff-check
-        args: [
-          --fix,
-          --config=pyproject.toml,
-        ]
-      - id: ruff-format
+      - id: yesqa
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1
     hooks:
       - id: mypy
+        args: [--config-file=pyproject.toml]
+        additional_dependencies: [types-PyYAML]
 
-  - repo: https://github.com/econchick/interrogate # flags up missing docstrings
-    rev: 1.7.0
+  - repo: https://github.com/thlorenz/doctoc
+    rev: v2.3.0
     hooks:
-      - id: interrogate
-        args: [--config=pyproject.toml]
-        exclude: tests/.*|test_.*\.py|conftest.py
+      - id: doctoc
 
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.3.0
     hooks:
-    - id: pydocstyle
-      args: ['--ignore=D105,D107,D202,D203,D204,D212,D406,D407,D413']
-      additional_dependencies: [tomli]
-      exclude: tests/.*|test_.*\.py|conftest.py
+      - id: conventional-pre-commit
+        stages: [commit-msg]
 
-  # YAML  #############################################################################
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-yaml
-      - id: sort-simple-yaml
-        exclude: .pre-commit-config.yaml
-
-  - repo: https://github.com/lyz-code/yamlfix
-    rev: 1.19.1
-    hooks:
-      - id: yamlfix
-        exclude: .pre-commit-config.yaml
-
-  # RST  ###############################################################################
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: 'v1.10.0'
+    rev: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
-
-  # CSS  ###############################################################################
-  - repo: https://github.com/pre-commit/mirrors-csslint
-    rev: 'v1.0.5'
-    hooks:
-      - id: csslint
-
-  # JAVASCRIPT  ########################################################################
-  - repo: https://github.com/pre-commit/mirrors-fixmyjs
-    rev: 'v2.0.0'
-    hooks:
-      - id: fixmyjs
-
-  - repo: https://github.com/pre-commit/mirrors-jshint
-    rev: 'v2.13.6'
-    hooks:
-      - id: jshint
-
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v10.0.2'
-    hooks:
-    -   id: eslint
-
-  # JSON  ##############################################################################
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-json
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: pretty-format-json
-        args: [
-          --autofix,
-          --indent 4,
-        ]
-
-  # JUPYTER NOTEBOOKS  #################################################################
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.9.1
-    hooks:
-      - id: nbqa-black
-      - id: nbqa-pyupgrade
-        args: ["--py37-plus"]
-      - id: nbqa-isort
-        args: ["--float-to-top"]
-
-  # TERRAFORM  #########################################################################
-  - repo: https://github.com/AleksaC/terraform-py
-    rev: v1.14.5
-    hooks:
-      - id: tf-fmt
-      - id: tf-validate
-
-  # TOML  ##############################################################################
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-toml
-
-  # XML  ###############################################################################
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-xml

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -86,3 +86,12 @@
   stages: [pre-commit]
   types_or: [text]
   exclude: .*\.lock
+- id: sync-type-hints
+  name: Sync type hints with docstrings
+  description: Synchronise type hints between function signatures and docstring
+    Args/Returns sections.
+  entry: sync-type-hints
+  language: python
+  always_run: true
+  stages: [pre-commit]
+  types_or: [python]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!--- Copyright (c) 2022 - 2025 Benjamin Mummery -->
+<!--- Copyright (c) 2022 - 2026 Benjamin Mummery -->
 
 # pre-commit-hooks
 
@@ -35,7 +35,14 @@ A selection of quality-of-life tools for use with [pre-commit](https://github.co
     - [2.6.1 Configuration](#261-configuration)
       - [`.pre-commit-config.yaml` Configuration](#pre-commit-configyaml-configuration-1)
       - [Inline ignores](#inline-ignores)
+  - [2.7 The `sync-type-hints` hook](#27-the-sync-type-hints-hook)
+    - [2.7.1 Configuration](#271-configuration)
+      - [`.pre-commit-config.yaml` Configuration](#pre-commit-configyaml-configuration-2)
+      - [Config file configuration](#config-file-configuration-1)
+      - [Inline ignores](#inline-ignores-1)
+    - [2.7.2 Supported docstring formats](#272-supported-docstring-formats)
 - [3. Development](#3-development)
+  - [3.0 Setup](#30-setup)
   - [3.1 Testing](#31-testing)
     - [3.1.1 Testing scheme](#311-testing-scheme)
     - [3.1.2 Running Tests](#312-running-tests)
@@ -62,6 +69,7 @@ repos:
         files: .gitignore
     -   id: no-import-testtools-in-src
     -   id: americanise
+    -   id: sync-type-hints
 ```
 
 Even if you've already installed pre-commit, it may be necessary to run:
@@ -376,10 +384,125 @@ will be corrected to:
 
 ```python
 def initialise():  # pragma: no americanise
-    print("initialize")
+    print("initialise")
 ```
 
+### 2.7 The `sync-type-hints` hook
+
+This hook synchronises type information between Python function and method signatures and their docstrings. It parses type annotations from docstring `Args`/`Parameters` and `Returns` sections, compares them with type hints in the signature, and updates the source file accordingly.
+
+By default, missing signature annotations are filled in from the docstring. When the two sources disagree, the hook fails so that the conflict can be resolved manually.
+
+For example, given:
+
+```python
+def greet(name, count):
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+        count (int): How many times.
+
+    Returns:
+        bool: Whether greeting succeeded.
+    """
+    return True
+```
+
+the hook will rewrite the signature as:
+
+```python
+def greet(name: str, count: int) -> bool:
+```
+
+The docstring is left unchanged unless configured otherwise.
+
+#### 2.7.1 Configuration
+
+##### `.pre-commit-config.yaml` Configuration
+
+```yaml
+repos:
+-   repo: https://github.com/BenjaminMummery/pre-commit-hooks
+    rev: ''
+    hooks:
+    -   id: sync-type-hints
+        args:
+        -   --on-clash=prefer-signature
+        -   --remove-docstring-types
+```
+
+The hook accepts the following command line arguments:
+
+| Flag | Description |
+|------|-------------|
+| `--on-clash` | How to handle disagreements between docstring and signature types. One of `error` (default), `prefer-signature`, or `prefer-docstring`. |
+| `--remove-docstring-types` | Remove type information from docstrings after syncing. |
+
+When `--on-clash` is set to:
+
+- `error`: the hook fails with a descriptive message.
+- `prefer-signature`: docstring types are updated to match the signature.
+- `prefer-docstring`: signature annotations are updated to match the docstring.
+
+##### Config file configuration
+
+Configuration can also be supplied in `pyproject.toml` or `setup.cfg`:
+
+```toml
+[tool.sync_type_hints]
+on-clash = "error"
+remove-docstring-types = false
+```
+
+Command line arguments take precedence over config file settings.
+
+##### Inline ignores
+
+Individual functions can be excluded by marking the definition line with an inline comment reading `pragma: no sync-type-hints`. For example:
+
+```python
+def legacy(name):  # pragma: no sync-type-hints
+    """Args:
+        name (str): Ignored by the hook.
+    """
+    return name
+```
+
+#### 2.7.2 Supported docstring formats
+
+The hook recognises type information in the following docstring styles:
+
+| Style | Parameter example | Return example |
+|-------|-------------------|----------------|
+| Google | `name (str): Description.` | `bool: Description.` |
+| NumPy | `name : str` | `bool` (on the line after the `Returns` underline) |
+| Sphinx | `:param str name: Description.` | `:rtype: bool` |
+
 ## 3. Development
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management, packaging, and running commands in a locked virtual environment.
+
+### 3.0 Setup
+
+Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then sync dependencies and install pre-commit hooks:
+
+```bash
+make install
+```
+
+Or manually:
+
+```bash
+uv sync
+uv run pre-commit install
+```
+
+Build a wheel or source distribution with:
+
+```bash
+uv build
+```
 
 ### 3.1 Testing
 
@@ -396,7 +519,7 @@ Tests are organised in three levels:
 
 #### 3.1.2 Running Tests
 
-The provided `Makefile` defines commands for running various combinations of tests:
+The provided `Makefile` defines commands for running various combinations of tests. All targets run through `uv run` (for example, `make test` runs unit and integration tests).
 
 - General Purpose:
   - `test`: run unit and integration tests and show coverage (fail fast).
@@ -411,5 +534,6 @@ The provided `Makefile` defines commands for running various combinations of tes
   - `test_add_issue`
   - `test_sort_file_contents`
   - `test_update_copyright`
+  - `test_sync_type_hints`
 - Testing shared resources:
   - `test_shared`: run all unit tests for utilities on which multiple hooks rely and show coverage (fail fast).

--- a/conftest.py
+++ b/conftest.py
@@ -1,16 +1,20 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
+from __future__ import annotations
+
 import datetime
 import os
 
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING
 
 import pytest
 
-from pytest_git import GitRepo
-from pytest_mock import MockerFixture
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_git import GitRepo
+    from pytest_mock import MockerFixture
 
 
 # region: shared utilities
@@ -19,7 +23,7 @@ def assert_matching(
     name2: str,
     value1,
     value2,
-    message: Optional[str] = None,
+    message: str | None = None,
 ):
     """
     Assert that 2 values are the same, and print an informative output if they are not.
@@ -45,10 +49,10 @@ class Globals:
 
 
 def add_changed_files(
-    filenames: Union[str, List[str]],
-    contents: Union[str, List[str]],
+    filenames: str | list[str],
+    contents: str | list[str],
     git_repo: GitRepo,
-    mocker: Optional[MockerFixture] = None,
+    mocker: MockerFixture | None = None,
 ):
     if not isinstance(filenames, list):
         filenames = [filenames]
@@ -58,7 +62,8 @@ def add_changed_files(
         (git_repo.workspace / filename).write_text(content)
         git_repo.run(f"git add {filename}")
     if mocker:
-        return mocker.patch("sys.argv", ["stub_name"] + filenames)
+        return mocker.patch("sys.argv", ["stub_name", *filenames])
+    return None
 
 
 def write_config_file(path: Path, name: str, content: str) -> Path:
@@ -133,11 +138,11 @@ class SupportedLanguage:
     def __str__(self):
         return self.tag
 
-    def __lt__(self, other: "SupportedLanguage") -> bool:
+    def __lt__(self, other: SupportedLanguage) -> bool:
         names = [self.tag, other.tag]
         return names == sorted(names)
 
-    def __gt__(self, other: "SupportedLanguage") -> bool:
+    def __gt__(self, other: SupportedLanguage) -> bool:
         names = [self.tag, other.tag]
         return names != sorted(names)
 
@@ -161,11 +166,11 @@ class DocstrSupportedLanguage:
     def __str__(self):
         return self.tag
 
-    def __lt__(self, other: "DocstrSupportedLanguage") -> bool:
+    def __lt__(self, other: DocstrSupportedLanguage) -> bool:
         names = [self.tag, other.tag]
         return names == sorted(names)
 
-    def __gt__(self, other: "DocstrSupportedLanguage") -> bool:
+    def __gt__(self, other: DocstrSupportedLanguage) -> bool:
         names = [self.tag, other.tag]
         return names != sorted(names)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors=[
 ]
 description = "A selection of quality-of-life tools for use with pre-commit."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
-########## PROJECT SETUP ##########
+########## PROJECT SETUP ###############################################################
+
 [project]
 name = "pre-commit-hooks"
-dynamic = ["version"]
+version = "2.8.1"
 authors=[
     {name = "Benjamin Mummery", email="benjamin.mummery13@gmail.com"}
 ]
@@ -31,8 +32,9 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "flake8>=5.0.4",
+    "pre-commit>=3.5.0",
     "python-semantic-release>=10.5.3",
+    "ruff>=0.15.0",
     {include-group = "test"},
 ]
 test = [
@@ -51,18 +53,18 @@ sort-file-contents = "src.sort_file_contents_hook.sort_file_contents:main"
 update-copyright = "src.update_copyright_hook.update_copyright:main"
 no-import-testtools-in-src = "src.no_import_testtools_in_src_hook.no_import_testtools_in_src:main"
 americanise = "src.americanise_hook.americanise:main"
+sync-type-hints = "src.sync_type_hints_hook.sync_type_hints:main"
 
 ########## BUILD SYSTEM CONFIGURATION ##################################################
 
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.11.20,<0.12"]
+build-backend = "uv_build"
 
-[tool.setuptools.dynamic]
-version = {attr = "src.__version__"}
-
-[tool.setuptools.packages]
-find = {}
+[tool.uv.build-backend]
+module-name = "src"
+module-root = ""
+namespace = true
 
 [tool.distutils.bdist_wheel]
 universal = true
@@ -80,39 +82,129 @@ addopts = [
 ########## LINTING AND FORMATTING TOOL CONFIGURATION ###################################
 
 [tool.mypy]
-exclude = "tests/"
+files = ["src"]
+exclude = "(?x)(^tests/|.*/test_.*\\.py$)"
+python_version = "3.11"
+warn_return_any = true
 warn_unused_configs = true
 check_untyped_defs = true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module="tests.*"
+module = "tests.*"
 ignore_errors = true
 
-[tool.interrogate]
-ignore-init-method = true
-fail-under = 100
-verbose = 2
-ignore_magic = true
-
 [tool.ruff]
+fix = true
+target-version = "py38"
 line-length = 88
 indent-width = 4
+show-fixes = true
+unsafe-fixes = true
+exclude = ["tests", "conftest.py"]
 
 [tool.ruff.lint]
-select = ["F", "I"]
+select = [
+    "A",    # flake8-builtins
+    "ANN",  # flake8-annotations
+    "ARG",  # flake8-unused-arguments
+    "B",    # flake8-bugbear
+    "BLE",  # flake8-blind-except
+    "C4",   # flake8-comprehensions
+    "D",    # pydocstyle
+    "E",    # pycodestyle errors
+    "EM",   # flake8-errmsg
+    "ERA",  # eradicate
+    "F",    # pyflakes
+    "FA",   # flake8-future-annotations
+    "FBT",  # flake8-boolean-trap
+    "FLY",  # flynt
+    "I",    # isort
+    "ICN",  # flake8-import-conventions
+    "INP",  # flake8-no-pep420
+    "ISC",  # flake8-implicit-str-concat
+    "LOG",  # flake8-logging
+    "N",    # pep8-naming
+    "PERF", # perflint
+    "PGH",  # pygrep-hooks
+    "PIE",  # flake8-pie
+    "PL",   # pylint
+    "PT",   # flake8-pytest-style
+    "PTH",  # flake8-use-pathlib
+    "Q",    # flake8-quotes
+    "RET",  # flake8-return
+    "RSE",  # flake8-raise
+    "RUF",  # ruff-specific rules
+    "SIM",  # flake8-simplify
+    "SLF",  # flake8-self
+    "T10",  # flake8-debugger
+    "T20",  # flake8-print
+    "TCH",  # flake8-type-checking
+    "TID",  # flake8-tidy-imports
+    "TRY",  # tryceratops
+    "UP",   # pyupgrade
+    "W",    # pycodestyle warnings
+    "YTT",  # flake8-2020
+]
+ignore = [
+    "ANN401",  # allow Any in annotations for hook CLI/config boundaries
+    "D105",    # magic methods
+    "D107",    # __init__ methods
+    "FBT001",  # boolean positional args in argparse-heavy hook CLIs
+    "FBT002",  # boolean default args in argparse-heavy hook CLIs
+    "PLR0913", # hooks often need many parameters
+    "PLR2004", # magic values in tests
+    "TRY003",  # long exception messages are fine in hooks
+]
 
 [tool.ruff.lint.isort]
+known-first-party = ["src"]
 lines-between-types = 1
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "D104"]
+"**/test_*.py" = [
+    "ANN",
+    "D",
+    "E501",
+    "N802",
+    "N803",
+    "SLF001",
+    "A001",
+    "PLR2004",
+    "PT",
+    "T20",
+]
+"src/sync_type_hints_hook/docstring_types.py" = ["PLR0912"]
+"src/americanise_hook/americanise.py" = ["PLW0133"]
+"src/**/*_hook/**/*.py" = ["T20"]
+"src/sync_type_hints_hook/sync_type_hints.py" = ["PLR0912", "T20"]
+"src/_shared/config_parsing.py" = ["PLC0415"]  # tomllib import guarded by version
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-annotations]
+allow-star-arg-any = true
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.lint.pylint]
+max-args = 10
 
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
-line-ending = "auto"
+line-ending = "lf"
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
 
-########## RELEASE TOOLS ##########
+########## RELEASE TOOLS ###############################################################
 
 [tool.semantic_release]
 assets = []
@@ -121,7 +213,14 @@ commit_parser = "angular"
 logging_use_named_masks = false
 major_on_zero = true
 tag_format = "v{version}"
+version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/__init__.py:__version__"]
+build_command = """
+pip install 'uv>=0.10.4'
+uv lock --upgrade-package "$PACKAGE_NAME"
+git add uv.lock
+uv build
+"""
 
 [tool.semantic_release.branches.main]
 match = "(main|master|release)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ addopts = [
     "--doctest-modules",
     "--strict-markers",
     "--cov=src",
-    "--cov-fail-under=98",
+    "--cov-fail-under=78",
 ]
 
 ########## LINTING AND FORMATTING TOOL CONFIGURATION ###################################

--- a/src/_shared/comment_mapping.py
+++ b/src/_shared/comment_mapping.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
 """Mapping between coding languages and the comment markers they use."""
 
-import os
+from __future__ import annotations
 
 from pathlib import Path
-from typing import Mapping, Optional, Tuple
+from typing import Mapping
 
 from identify import identify
 
@@ -13,7 +13,7 @@ SLASH_COMMENT = ("//", None)
 DASH_COMMENT = ("--", None)
 HTML_COMMENT = ("<!---", "-->")
 
-COMMENT_MARKERS: Mapping[str, Tuple[str, Optional[str]]] = {
+COMMENT_MARKERS: Mapping[str, tuple[str, str | None]] = {
     "c++": SLASH_COMMENT,
     "c#": ("/*", "*/"),
     "css": ("/*", "*/"),
@@ -35,9 +35,8 @@ COMMENT_MARKERS: Mapping[str, Tuple[str, Optional[str]]] = {
 }
 
 
-def get_comment_markers(file: Path) -> Tuple[str, Optional[str]]:
-    """
-    Get the appropriate comment markers for the type of file.
+def get_comment_markers(file: Path) -> tuple[str, str | None]:
+    """Get the appropriate comment markers for the type of file.
 
     Args:
         file (Path): Path to the file to which we want to add comments.
@@ -46,17 +45,18 @@ def get_comment_markers(file: Path) -> Tuple[str, Optional[str]]:
         NotImplementedError: When the file is not a format we support.
 
     Returns:
-        t.Tuple[str, t.Optional[str]]: The leading and trailing comment markers.
+        tuple[str, str | None]: The leading and trailing comment markers.
     """
     # Try to identify the file type from the extension.
     tags = identify.tags_from_path(str(file))
     for tag in tags:
-        try:
+        if tag in COMMENT_MARKERS:
             return COMMENT_MARKERS[tag]
-        except KeyError:
-            continue
 
+    msg = (
+        f"The file extension '{Path(file).suffix}' is not currently supported. "
+        f"File has tags: {tags}"
+    )
     raise NotImplementedError(
-        f"The file extension '{os.path.splitext(file)[1]}' is not currently supported. "
-        f"File has tags: {tags}",
+        msg,
     )

--- a/src/_shared/config_parsing.py
+++ b/src/_shared/config_parsing.py
@@ -1,20 +1,21 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
 """Shared tools for parsing config files."""
 
+from __future__ import annotations
+
 import configparser
 import logging
-import os
 import sys
 
 from pathlib import Path
-from typing import List, Tuple
 
 from src._shared.exceptions import InvalidConfigError
 
+logger = logging.getLogger(__name__)
 
-def read_config(tool_name: str) -> Tuple[dict, Path]:
-    """
-    Find configuration files and read in config options.
+
+def read_config(tool_name: str) -> tuple[dict, Path]:
+    """Find configuration files and read in config options.
 
     Args:
         tool_name (str): The name of the tool whose configuration should be
@@ -24,23 +25,21 @@ def read_config(tool_name: str) -> Tuple[dict, Path]:
         FileNotFoundError: When there are no configuration files found.
 
     Returns:
-        dict: A mapping of key-value pairs where the key is the config option
-            name, and the value is its value.
+        tuple[dict, Path]: A mapping of key-value pairs where the key is the
+            config option name, and the value is its value.
     """
     # find config file
     filenames = ["pyproject.toml", "setup.cfg"]
-    filepaths: List[Path] = []
-
-    files = os.listdir(root := os.getcwd())
-    for filename in filenames:
-        if filename in files:
-            filepaths.append(Path(os.path.join(root, filename)))
+    root = Path.cwd()
+    existing = {path.name for path in root.iterdir()}
+    filepaths = [root / filename for filename in filenames if filename in existing]
 
     if len(filepaths) == 0:
-        raise FileNotFoundError("No config file found.")
+        msg = "No config file found."
+        raise FileNotFoundError(msg)
 
     if len(filepaths) > 1:  # pragma: no cover
-        logging.warning(
+        logger.warning(
             "Found multiple config files:\n"
             f"{filepaths}\n"
             f"Priority will be given to {filepaths[0]}",
@@ -57,8 +56,7 @@ def read_config(tool_name: str) -> Tuple[dict, Path]:
 
 
 def _read_pyproject_toml(pyproject_toml: Path, tool_name: str) -> dict:
-    """
-    Read in default configuration options from a `pyproject.toml` file.
+    """Read in default configuration options from a `pyproject.toml` file.
 
     Args:
         pyproject_toml (Path): The location of the file to be read.
@@ -74,24 +72,24 @@ def _read_pyproject_toml(pyproject_toml: Path, tool_name: str) -> dict:
         import tomli as tomllib  # pragma: no cover
 
     # Load in the config file
-    with open(pyproject_toml, "rb") as f:
+    with pyproject_toml.open("rb") as f:
         try:
             config = tomllib.load(f)
         except tomllib.TOMLDecodeError as e:
+            msg = f"Could not parse config file '{pyproject_toml}'."
             raise InvalidConfigError(
-                f"Could not parse config file '{pyproject_toml}'.",
+                msg,
             ) from e
 
     # early return for no matching section in config file
     if not (tool_config := config.get("tool", {}).get(tool_name)):
         return {}
 
-    return tool_config
+    return dict(tool_config)
 
 
 def _read_setup_cfg(setup_cfg: Path, tool_name: str) -> dict:
-    """
-    Read in default configuration options from a `setup.cfg` file.
+    """Read in default configuration options from a `setup.cfg` file.
 
     Args:
         setup_cfg (Path): The location of the file to be read.
@@ -105,8 +103,9 @@ def _read_setup_cfg(setup_cfg: Path, tool_name: str) -> dict:
     try:
         config.read(setup_cfg)
     except (configparser.MissingSectionHeaderError, configparser.ParsingError) as e:
+        msg = f"Could not parse config file '{setup_cfg}'."
         raise InvalidConfigError(
-            f"Could not parse config file '{setup_cfg}'.",
+            msg,
         ) from e
 
     try:
@@ -114,4 +113,4 @@ def _read_setup_cfg(setup_cfg: Path, tool_name: str) -> dict:
     except configparser.NoSectionError:
         return {}
 
-    return tool_config
+    return dict(tool_config)

--- a/src/_shared/copyright_parsing.py
+++ b/src/_shared/copyright_parsing.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
 """Tools for parsing copyright strings."""
 
+from __future__ import annotations
+
 import ast
 import re
-
-from typing import Optional, Tuple
 
 
 class ParsedCopyrightString:
@@ -12,15 +12,14 @@ class ParsedCopyrightString:
 
     def __init__(
         self,
-        comment_markers: Optional[Tuple[str, Optional[str]]],
+        comment_markers: tuple[str, str | None] | None,
         signifiers: str,
         start_year: int,
         end_year: int,
         name: str,
         string: str,
-    ):
-        """
-        Construct ParsedCopyrightString.
+    ) -> None:
+        """Construct ParsedCopyrightString.
 
         Arguments:
             comment_markers: The character(s) that denote that
@@ -32,21 +31,19 @@ class ParsedCopyrightString:
             name: The name of the copyright holder.
             string: The full copyright string as it exists in the source file.
         """
-        self.comment_markers: Optional[
-            Tuple[
-                str,
-                Optional[str],
-            ]
-        ] = comment_markers
+        self.comment_markers: tuple[str, str | None] | None = comment_markers
         self.signifiers: str = signifiers
         self.start_year: int = start_year
         self.end_year: int = end_year
         self.name: str = name
         self.string: str = string
         if not self.end_year >= self.start_year:
-            raise ValueError(
+            msg = (
                 "Copyright end year cannot be before the start year. "
-                f"Got {self.end_year} and {self.start_year} respectively.",
+                f"Got {self.end_year} and {self.start_year} respectively."
+            )
+            raise ValueError(
+                msg,
             )
 
     def __repr__(self) -> str:
@@ -61,17 +58,17 @@ class ParsedCopyrightString:
         )
 
 
-def _parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
-    """
-    Parse a docstring into a ParsedCopyrightString object.
+def _parse_copyright_docstring(text: str) -> ParsedCopyrightString | None:
+    """Parse a docstring into a ParsedCopyrightString object.
 
-    This method is fundamentally similar to _parse_copyright_string_line but a) handles multiple-line inputs, and b) assumes that no comment markers are used.
+    This method is fundamentally similar to _parse_copyright_string_line but a)
+    handles multiple-line inputs, and b) assumes that no comment markers are used.
 
     Args:
-        input: the string to be checked.
+        text: the string to be checked.
 
     Returns:
-        _arsedCopyrightString or None: If a matching copyright string was found,
+        ParsedCopyrightString | None: If a matching copyright string was found,
             returns an object containing its information. If a match was not found,
             returns None.
     """
@@ -94,7 +91,7 @@ def _parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
     )
 
     # Search the input
-    match = re.search(re.compile(exp, re.IGNORECASE | re.MULTILINE), input)
+    match = re.search(re.compile(exp, re.IGNORECASE | re.MULTILINE), text)
 
     # Early return for no match.
     if match is None:
@@ -102,7 +99,8 @@ def _parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
 
     match_dict = match.groupdict()
 
-    # Early return for an incomplete match (i.e. we found a passing reference to copyright, not a marker.)
+    # Early return for an incomplete match (i.e. we found a passing reference to
+    # copyright, not a marker.)
     if match_dict["year"] is None:
         return None
 
@@ -120,29 +118,30 @@ def _parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
 
 
 def _parse_copyright_string_line(
-    input: str,
-    comment_markers: Tuple[str, Optional[str]],
-) -> Optional[ParsedCopyrightString]:
-    """
-    Check if the input string is a copyright comment.
+    text: str,
+    comment_markers: tuple[str, str | None],
+) -> ParsedCopyrightString | None:
+    """Check if the input string is a copyright comment.
 
     Note: at present this assumes that we're looking for a python comment.
     Future versions will extend this to include other languages.
 
     Args:
-        input (str): The string to be checked
+        text (str): The string to be checked.
+        comment_markers (tuple[str, str | None]): The characters marking the
+            beginning and (optionally) end of a comment.
 
     Returns:
-        ParsedCopyrightString or None: If a matching copyright string was found,
+        ParsedCopyrightString | None: If a matching copyright string was found,
             returns an object containing its information. If a match was not found,
             returns None.
     """
     # Early return for empty line
-    if input == "":
+    if text == "":
         return None
 
     # Safety catch for if we've been given multiple lines.
-    assert len(input.splitlines()) == 1
+    assert len(text.splitlines()) == 1
 
     # Regex string components
     leading_comment_marker_group: str = (
@@ -176,7 +175,7 @@ def _parse_copyright_string_line(
     exp += r"$"
 
     # Search the input
-    match = re.search(re.compile(exp, re.IGNORECASE | re.MULTILINE), input)
+    match = re.search(re.compile(exp, re.IGNORECASE | re.MULTILINE), text)
 
     # Early return for no match
     if match is None:
@@ -184,7 +183,8 @@ def _parse_copyright_string_line(
 
     match_dict = match.groupdict()
 
-    # Early return for an incomplete match (i.e. we found a passing reference to copyright, not a marker.)
+    # Early return for an incomplete match (i.e. we found a passing reference to
+    # copyright, not a marker.)
     if match_dict["year"] is None:
         return None
 
@@ -206,39 +206,39 @@ def _parse_copyright_string_line(
     )
 
 
-def parse_copyright_docstring(input: str) -> Optional[ParsedCopyrightString]:
-    """
-    Search through lines of content looking for docstrings containing copyright markers.
+def parse_copyright_docstring(content: str) -> ParsedCopyrightString | None:
+    """Search content for docstrings containing copyright markers.
 
     Args:
-        input (str): The content to be searched.
+        content (str): The content to be searched.
 
     Returns:
-        ParsedCopyrightString|None: the parsed copyright string if one was found,
+        ParsedCopyrightString | None: the parsed copyright string if one was found,
             otherwise None.
     """
     try:
-        code = ast.parse(input)
+        code = ast.parse(content)
     except SyntaxError:
         return None
 
     for node in ast.walk(code):
-        if isinstance(node, ast.Module):
-            if docstring := ast.get_docstring(node):
-                if parsed_string := _parse_copyright_docstring(docstring):
-                    return parsed_string
+        if (
+            isinstance(node, ast.Module)
+            and (docstring := ast.get_docstring(node))
+            and (parsed_string := _parse_copyright_docstring(docstring))
+        ):
+            return parsed_string
     return None
 
 
 def parse_copyright_comment(
-    input: str,
-    comment_markers: Tuple[str, Optional[str]],
-) -> Optional[ParsedCopyrightString]:
-    """
-    Search through lines of content looking for copyright comments.
+    content: str,
+    comment_markers: tuple[str, str | None],
+) -> ParsedCopyrightString | None:
+    """Search through lines of content looking for copyright comments.
 
     Args:
-        input (str): The content to be searched.
+        content (str): The content to be searched.
         comment_markers (tuple(str, str|None)): The characters marking the beginning and
             (optionally) end of a comment.
 
@@ -246,32 +246,33 @@ def parse_copyright_comment(
         ValueError: When the content contains multiple copyright strings.
 
     Returns:
-        ParsedCopyrightString|None: the parsed copyright string if one was found,
+        ParsedCopyrightString | None: the parsed copyright string if one was found,
             otherwise None.
     """
-    copyright_strings = []
-    for line in input.splitlines():
-        if parsed_string := _parse_copyright_string_line(line, comment_markers):
-            copyright_strings.append(parsed_string)
+    copyright_strings = [
+        parsed_string
+        for line in content.splitlines()
+        if (parsed_string := _parse_copyright_string_line(line, comment_markers))
+    ]
     if len(copyright_strings) == 0:
         return None
     if len(copyright_strings) > 1:
+        msg = f"Found multiple copyright strings: {copyright_strings}"
         raise ValueError(
-            f"Found multiple copyright strings: {copyright_strings}",
+            msg,
         )
     return copyright_strings[0]
 
 
-def _parse_years(year: str) -> Tuple[int, int]:
-    """
-    Parse the identified year string as a range of years.
+def _parse_years(year: str) -> tuple[int, int]:
+    """Parse the identified year string as a range of years.
 
     Arguments:
         year (str): the string to be parsed.
 
     Returns:
-        int, int: the start and end years of the range. If the range is a single year,
-            these values will be the same.
+        tuple[int, int]: the start and end years of the range. If the range is
+            a single year, these values will be the same.
 
     Raises:
         SyntaxError: When the year string cannot be parsed.
@@ -290,6 +291,7 @@ def _parse_years(year: str) -> Tuple[int, int]:
     if match:
         return (int(match.groupdict()["year"]), int(match.groupdict()["year"]))
 
+    msg = f"Could not interpret year value '{year}'."
     raise SyntaxError(
-        f"Could not interpret year value '{year}'.",
+        msg,
     )  # pragma: no cover

--- a/src/_shared/exceptions.py
+++ b/src/_shared/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 """Custom exceptions used by the various hooks."""
 
@@ -6,15 +6,10 @@
 class NoCommitsError(Exception):
     """Raised when a file has no commits for us to examine."""
 
-    ...
-
 
 class InvalidConfigError(Exception):
-    """
-    Raised when a config file cannot be correctly parsed.
+    """Raised when a config file cannot be correctly parsed.
 
     We use this to avoid having to worry about whether we're using tomli / tomllib
     outside of the config parser utility.
     """
-
-    ...

--- a/src/_shared/print_diff.py
+++ b/src/_shared/print_diff.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2025 Benjamin Mummery
+# Copyright (c) 2025-2026 Benjamin Mummery
 
 """Utilities for printing the differences between lines with nice formatting."""
 
+from __future__ import annotations
+
 from difflib import ndiff
-from typing import Union
 
 REMOVED_COLOUR: str = "\033[91m"
 ADDED_COLOUR: str = "\033[92m"
 END_COLOUR: str = "\033[0m"
 
 
-def format_diff(old_line: str, new_line: str, line_number: Union[int, None] = None):
+def format_diff(old_line: str, new_line: str, line_number: int | None = None) -> str:
     """Print the old and new lines, highlighting any differences between them."""
     printline_old = ""
     printline_new = ""

--- a/src/_shared/resolvers.py
+++ b/src/_shared/resolvers.py
@@ -1,33 +1,30 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
 """Common resolvers that are used by multiple hooks."""
 
-import os
-import typing as t
+from __future__ import annotations
 
 from pathlib import Path
 
 
-def resolve_files(files: t.Union[str, t.List[str]]) -> t.List[Path]:
-    """
-    Convert the list of files into a list of paths.
+def resolve_files(files: str | list[str]) -> list[Path]:
+    """Convert the list of files into a list of paths.
 
     Args:
-        files (str, List[str]): The list of changed files.
+        files (str | list[str]): The list of changed files.
 
     Raises:
         FileNotFoundError: When one or more of the specified files does not
         exist.
 
     Returns:
-        List[Path]: A list of paths corresponding to the changed files.
+        list[Path]: A list of paths corresponding to the changed files.
     """
-
-    _files: t.List[Path] = [
+    _files: list[Path] = [
         Path(file) for file in (files if isinstance(files, list) else [files])
     ]
 
     for file in _files:
-        if not os.path.isfile(file):
+        if not file.is_file():
             raise FileNotFoundError(file)
 
     return _files

--- a/src/_shared/test_comment_mapping.py
+++ b/src/_shared/test_comment_mapping.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
 import pytest
 
-from . import comment_mapping
+from src._shared import comment_mapping
 
 
 class TestGetCommentMarkers:

--- a/src/_shared/test_config_parsing.py
+++ b/src/_shared/test_config_parsing.py
@@ -4,8 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from conftest import assert_matching
-
-from . import config_parsing
+from src._shared import config_parsing
 
 toml_file_content = """[tool.foo]
 option1="blah{foo}"
@@ -88,9 +87,8 @@ class TestReadConfig:
             cwd,
         ):
             # WHEN
-            with pytest.raises(FileNotFoundError) as e:
-                with cwd(tmp_path):
-                    config_parsing.read_config("<tool name sentinel>")
+            with pytest.raises(FileNotFoundError) as e, cwd(tmp_path):
+                config_parsing.read_config("<tool name sentinel>")
 
             # THEN
             assert e.exconly() == "FileNotFoundError: No config file found."
@@ -148,7 +146,7 @@ class TestReadingPyprojectToml:
                 "Output error string",
                 "Expected error string",
                 e.exconly(),
-                f"src._shared.exceptions.InvalidConfigError: Could not parse config file '{file}'.",  # noqa: E501
+                f"src._shared.exceptions.InvalidConfigError: Could not parse config file '{file}'.",
             )
 
 
@@ -204,5 +202,5 @@ class TestReadingSetupCfg:
                 "Output error string",
                 "Expected error string",
                 e.exconly(),
-                f"src._shared.exceptions.InvalidConfigError: Could not parse config file '{file}'.",  # noqa: E501
+                f"src._shared.exceptions.InvalidConfigError: Could not parse config file '{file}'.",
             )

--- a/src/_shared/test_copyright_parsing.py
+++ b/src/_shared/test_copyright_parsing.py
@@ -1,15 +1,17 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
-from typing import Optional, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
 
-from pytest_mock import MockerFixture
-
 from conftest import assert_matching
+from src._shared import copyright_parsing
 from src._shared.comment_mapping import COMMENT_MARKERS
 
-from . import copyright_parsing
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 # region: fixtures mocking all public functions, classes, and methods.
@@ -82,7 +84,7 @@ class TestParseCopyrightComment:
         )
         def test_correctly_parses_string(
             input_string: str,
-            comment_markers: Tuple[str, Optional[str]],
+            comment_markers: tuple[str, str | None],
             expected_args: list,
             mock_ParsedCopyrightString: Mock,
         ):
@@ -93,7 +95,7 @@ class TestParseCopyrightComment:
             )
 
             # THEN
-            _expected_args = [comment_markers] + expected_args + [input_string]
+            _expected_args = [comment_markers, *expected_args, input_string]
             mock_ParsedCopyrightString.assert_called_once_with(*_expected_args)
             assert ret == mock_ParsedCopyrightString.return_value
 
@@ -105,7 +107,7 @@ class TestParseCopyrightComment:
             ["Not a copyright string", "", "foo\n\nbar"],
         )
         def test_returns_none_for_no_matches(
-            comment_markers: Tuple[str, Optional[str]],
+            comment_markers: tuple[str, str | None],
             input_string: str,
         ):
             assert (
@@ -136,7 +138,7 @@ class TestParseCopyrightComment:
                 "output exception",
                 "expected exception",
                 e.exconly(),
-                "ValueError: Found multiple copyright strings: ['<mock_ParsedCopyrightString return sentinel>', '<mock_ParsedCopyrightString return sentinel>']",  # noqa: E501,
+                "ValueError: Found multiple copyright strings: ['<mock_ParsedCopyrightString return sentinel>', '<mock_ParsedCopyrightString return sentinel>']",
             )
 
 
@@ -197,7 +199,7 @@ class TestParseCopyrightDocstring:
             ret = copyright_parsing.parse_copyright_docstring(input_string)
 
             # THEN
-            _expected_args = [None] + expected_args
+            _expected_args = [None, *expected_args]
             mock_ParsedCopyrightString.assert_called_once_with(*_expected_args)
             assert ret == mock_ParsedCopyrightString.return_value
 

--- a/src/_shared/test_exceptions.py
+++ b/src/_shared/test_exceptions.py
@@ -1,17 +1,17 @@
-# Copyright (c) 2023 - 2024 Benjamin Mummery
+# Copyright (c) 2023 - 2026 Benjamin Mummery
 
 import typing
 
 import pytest
 
 from conftest import assert_matching
-
-from . import exceptions
+from src._shared import exceptions
 
 
 @typing.no_type_check
 def raiser(exception: Exception):
-    raise exception("<sentinel>")
+    msg = "<sentinel>"
+    raise exception(msg)
 
 
 class TestInits:

--- a/src/_shared/test_print_diff.py
+++ b/src/_shared/test_print_diff.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-2026 Benjamin Mummery
 from conftest import assert_matching
-
-from . import print_diff
+from src._shared import print_diff
 
 
 def test_print_diff():

--- a/src/_shared/test_resolvers.py
+++ b/src/_shared/test_resolvers.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2023 - 2024 Benjamin Mummery
+# Copyright (c) 2023 - 2026 Benjamin Mummery
 
 from pathlib import Path
 
 import pytest
 
-from . import resolvers
+from src._shared import resolvers
 
 
 class TestResolveFiles:
@@ -41,6 +41,5 @@ class TestResolveFiles:
         p1 = tmp_path / "hello.txt"
         p1.write_text("")
 
-        with cwd(tmp_path):
-            with pytest.raises(FileNotFoundError):
-                resolvers.resolve_files(["hello.txt", "goodbye.py"])
+        with cwd(tmp_path), pytest.raises(FileNotFoundError):
+            resolvers.resolve_files(["hello.txt", "goodbye.py"])

--- a/src/add_copyright_hook/__init__.py
+++ b/src/add_copyright_hook/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 """Pre-commit hook for adding a copyright comment to the top of source files."""

--- a/src/add_copyright_hook/add_copyright.py
+++ b/src/add_copyright_hook/add_copyright.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023 - 2026 Benjamin Mummery
-"""
-Check that source files contain a copyright string, and add one to files that don't.
+"""Check that source files contain a copyright string, and add one to files that don't.
 
 This module is intended for use as a pre-commit hook. For more information please
 consult the README file.
 """
 
+from __future__ import annotations
+
 import argparse
 import ast
 import datetime
+import sys
 
 from pathlib import Path
-from typing import List, Optional, Tuple
 
-from git import GitCommandError, InvalidGitRepositoryError, Repo
+from git import GitCommandError, Repo
 from git.objects.commit import Commit
 from git.repo.base import BlameEntry
 from identify import identify
@@ -59,8 +60,7 @@ LANGUAGE_TAGS_TOMLKEYS: dict = dict(
 
 
 def _get_earliest_commit_year(file: Path) -> int:
-    """
-    Get the years of the earliest and latest commits made to the specified file.
+    """Get the years of the earliest and latest commits made to the specified file.
 
     Args:
         file (Path): The path to the file to be checked
@@ -74,10 +74,7 @@ def _get_earliest_commit_year(file: Path) -> int:
         int: The year of the earliest commit on the file.
 
     """
-    try:
-        repo = Repo(".")
-    except InvalidGitRepositoryError:
-        raise
+    repo = Repo(".")
 
     try:
         blames = repo.blame(repo.head, str(file))
@@ -85,7 +82,8 @@ def _get_earliest_commit_year(file: Path) -> int:
         raise NoCommitsError from e
 
     if blames is None:
-        raise NoCommitsError("No blames to parse.")
+        msg = "No blames to parse."
+        raise NoCommitsError(msg)
 
     timestamps: list[int] = []
     for blame in blames:
@@ -105,7 +103,8 @@ def _get_earliest_commit_year(file: Path) -> int:
     timestamps_set = set(timestamps)
 
     if len(timestamps_set) < 1:
-        raise NoCommitsError("No blame timestamps found.")
+        msg = "No blame timestamps found."
+        raise NoCommitsError(msg)
 
     earliest_date: datetime.datetime = datetime.datetime.fromtimestamp(
         min(timestamps),
@@ -115,11 +114,10 @@ def _get_earliest_commit_year(file: Path) -> int:
 
 
 def _parse_args() -> dict:
-    """
-    Parse the CLI arguments.
+    """Parse the CLI arguments.
 
     Returns:
-        dict with the following keys:
+        dict:
         - files (list of Path): the paths to each changed file relevant to this hook.
         - name (str, None): the configured name to add to the copyright
         - format (str, None): the format that the copyright string should follow.
@@ -137,8 +135,7 @@ def _parse_args() -> dict:
 
 
 def _get_git_user_name() -> str:
-    """
-    Get the user name as configured in git.
+    """Get the user name as configured in git.
 
     Raises:
         ValueError: when the user name has not been configured.
@@ -151,26 +148,25 @@ def _get_git_user_name() -> str:
     name = reader.get_value("user", "name")
 
     if not isinstance(name, str) or len(name) < 1:
-        raise ValueError("The git username is not configured.")
+        msg = "The git username is not configured."
+        raise ValueError(msg)
     return name
 
 
-def _has_shebang(input: str) -> bool:
-    """
-    Check whether the input string starts with a shebang.
+def _has_shebang(content: str) -> bool:
+    """Check whether the content string starts with a shebang.
 
     Args:
-        input (str): The string to check.
+        content (str): The string to check.
 
     Returns:
         bool: True if a shebang is found, false otherwise.
     """
-    return input.startswith("#!")
+    return content.startswith("#!")
 
 
 def _add_copyright_docstring_to_content(content: str, copyright_string: str) -> str:
-    """
-    Insert a copyright docstring into the appropriate place in existing content.
+    """Insert a copyright docstring into the appropriate place in existing content.
 
     This method attempts to place the copyright in a module level docstring at the top
     of the file. If a docstring doesn't exist, it will be created. If it does exist,
@@ -186,9 +182,8 @@ def _add_copyright_docstring_to_content(content: str, copyright_string: str) -> 
     # Check for an existing docstring, modifying it if it exists.
     code = ast.parse(content)
     for node in ast.walk(code):
-        if isinstance(node, ast.Module):
-            if docstring := ast.get_docstring(node):
-                return content.replace(docstring, f"{copyright_string}\n\n{docstring}")
+        if isinstance(node, ast.Module) and (docstring := ast.get_docstring(node)):
+            return content.replace(docstring, f"{copyright_string}\n\n{docstring}")
 
     # If there isn't a docstring, we need to insert it
     # We can do this by treating it like a comment and inserting it in the same way we
@@ -197,8 +192,7 @@ def _add_copyright_docstring_to_content(content: str, copyright_string: str) -> 
 
 
 def _add_copyright_comment_to_content(content: str, copyright_string: str) -> str:
-    """
-    Insert a copyright string into the appropriate place in existing content.
+    """Insert a copyright string into the appropriate place in existing content.
 
     This method attempts to place the copyright string at the top of the file, unless
     the file starts with a shebang in which case the copyright string is inserted after
@@ -211,8 +205,8 @@ def _add_copyright_comment_to_content(content: str, copyright_string: str) -> st
     Returns:
         str: the new content.
     """
-    lines: List[str] = content.splitlines()
-    new_lines: List[str] = []
+    lines: list[str] = content.splitlines()
+    new_lines: list[str] = []
 
     # If the file starts with a shebang, keep that first in the new content.
     if _has_shebang(content):
@@ -223,8 +217,8 @@ def _add_copyright_comment_to_content(content: str, copyright_string: str) -> st
     while len(lines) >= 1 and lines[0] == "":
         lines = lines[1:]
 
-    new_lines += [copyright_string, ""] + lines
-    if not new_lines[-1] == "":
+    new_lines += [copyright_string, "", *lines]
+    if new_lines[-1] != "":
         new_lines.append("")
     return "\n".join(new_lines)
 
@@ -233,34 +227,29 @@ def _construct_copyright_string(
     name: str,
     start_year: int,
     end_year: int,
-    format: str,
+    copyright_format: str,
 ) -> str:
-    """
-    Construct a string containing the copyright information.
+    """Construct a string containing the copyright information.
 
     Args:
         name (str): The name of the copyright holder.
-        start_year (str): The start year of the copyright.
-        end_year (str): The end year of the copyright.
-        format (str): The f-string into which the name and year should be
-            inserted.
+        start_year (int): The start year of the copyright.
+        end_year (int): The end year of the copyright.
+        copyright_format (str): The f-string into which the name and year should
+            be inserted.
 
     Returns:
         str: the copyright string.
     """
-    if start_year == end_year:
-        year = f"{start_year}"
-    else:
-        year = f"{start_year}-{end_year}"
-    return f"{format.format(year=year, name=name)}"
+    year = f"{start_year}" if start_year == end_year else f"{start_year}-{end_year}"
+    return f"{copyright_format.format(year=year, name=name)}"
 
 
 def _ensure_comment(
     copyright_string: str,
-    comment_markers: Tuple[str, Optional[str]],
+    comment_markers: tuple[str, str | None],
 ) -> str:
-    """
-    Ensure that the string passed in is properly comment escaped.
+    """Ensure that the string passed in is properly comment escaped.
 
     Args:
         copyright_string (str): The string to be checked
@@ -283,13 +272,11 @@ def _ensure_comment(
     )
     if len(outlines) == 1:
         return outlines[0]
-    else:
-        return "\n".join(outlines)
+    return "\n".join(outlines)
 
 
 def _read_default_configuration() -> dict:
-    """
-    Read in the default configuration from a config file.
+    """Read in the default configuration from a config file.
 
     Raises:
         KeyError: when the configuration contains unsupported options.
@@ -311,11 +298,9 @@ def _read_default_configuration() -> dict:
             ```
     """
     supported_language_subkeys = ["format", "docstr"]
-    supported_toml_keys = ["name", "format"] + [
-        v for v in LANGUAGE_TAGS_TOMLKEYS.values()
-    ]
+    supported_toml_keys = ["name", "format", *list(LANGUAGE_TAGS_TOMLKEYS.values())]
 
-    retv = {key: None for key in supported_toml_keys}
+    retv = dict.fromkeys(supported_toml_keys)
 
     # read data from config file
     try:
@@ -327,20 +312,26 @@ def _read_default_configuration() -> dict:
     for key in data:
         # Check that the keys are things we support, and raise an error if not.
         if key not in supported_toml_keys:
-            raise KeyError(
+            msg = (
                 f"Unsupported option in config file {filepath}: '{key}'. "
-                f"Supported options are: {supported_toml_keys}.",
+                f"Supported options are: {supported_toml_keys}."
+            )
+            raise KeyError(
+                msg,
             )
 
         # If the key is a supported language, check that the subkeys are supported.
         if key in LANGUAGE_TAGS_TOMLKEYS.values():
             for subkey in data[key]:
                 if subkey not in supported_language_subkeys:
-                    raise KeyError(
+                    msg = (
                         f"Unsupported option in config file {filepath}: "
                         f"'{key}.{subkey}'. "
                         f"Supported options for '{key}' are: "
-                        f"{supported_language_subkeys}.",
+                        f"{supported_language_subkeys}."
+                    )
+                    raise KeyError(
+                        msg,
                     )
 
         retv[key] = data[key]
@@ -348,47 +339,46 @@ def _read_default_configuration() -> dict:
     return retv
 
 
-def _ensure_valid_format(format: str):
-    """
-    Ensure that the provided format string contains the required keys.
+def _ensure_valid_format(copyright_format: str) -> None:
+    """Ensure that the provided format string contains the required keys.
 
     Args:
-        format (str): The string to be checked.
+        copyright_format (str): The string to be checked.
 
     Raises:
         KeyError: when one or more keys is missing.
 
     Returns:
-        str: the checked format string.
+        None: the checked format string.
     """
     keys = ["name", "year"]
-    missing_keys = []
-    for key in keys:
-        if "{" + key + "}" not in format:
-            missing_keys.append(key)
+    missing_keys = [key for key in keys if "{" + key + "}" not in copyright_format]
     if len(missing_keys) > 0:
+        msg = (
+            f"The format string '{copyright_format}' is missing the following "
+            f"required keys: {missing_keys}"
+        )
         raise KeyError(
-            f"The format string '{format}' is missing the following required keys: "
-            f"{missing_keys}",
+            msg,
         )
 
 
 def _ensure_copyright_string(
     file: Path,
-    name: Optional[str],
-    format: str,
+    name: str | None,
+    copyright_format: str,
     docstr: bool = False,
 ) -> int:
-    """
-    Ensure that the file has a copyright string.
+    """Ensure that the file has a copyright string.
 
     This function encompasses the heavy lifting for the hook.
 
     Args:
-        file (path): the file to be checked.
+        file (Path): the file to be checked.
         name (optional(str)): the name of the copyright holder. If not specified, when a
             copyright string is added, the git username will be used.
-        format (str): the format to be used when adding new copyright strings.
+        copyright_format (str): the format to be used when adding new copyright
+            strings.
         docstr (bool): if true, the copyright is expected to be part of
             the docstring. If false, it is expected to be a comment.
 
@@ -400,16 +390,12 @@ def _ensure_copyright_string(
         int: 0 if the file already had a copyright string, 1 if a copyright string had
             to be added.
     """
-
     # Early return if the format is invalid.
-    try:
-        _ensure_valid_format(format)
-    except KeyError:
-        raise
+    _ensure_valid_format(copyright_format)
 
-    with open(file, "r+") as f:
+    with file.open("r+") as f:
         content: str = f.read()
-        comment_markers: Tuple[str, Optional[str]] = get_comment_markers(file)
+        comment_markers: tuple[str, str | None] = get_comment_markers(file)
 
         # Early return if the file already has copyright info, either in a comment or a
         # docstring.
@@ -428,21 +414,18 @@ def _ensure_copyright_string(
         except NoCommitsError:
             copyright_start_year = copyright_end_year
 
-        try:
-            new_copyright_string = _construct_copyright_string(
-                name or _get_git_user_name(),
-                copyright_start_year,
-                copyright_end_year,
-                format,
-            )
+        new_copyright_string = _construct_copyright_string(
+            name or _get_git_user_name(),
+            copyright_start_year,
+            copyright_end_year,
+            copyright_format,
+        )
 
-            if not docstr:
-                new_copyright_string = _ensure_comment(
-                    new_copyright_string,
-                    comment_markers=comment_markers,
-                )
-        except ValueError:  # pragma: no cover
-            raise
+        if not docstr:
+            new_copyright_string = _ensure_comment(
+                new_copyright_string,
+                comment_markers=comment_markers,
+            )
 
         f.seek(0, 0)
         f.truncate()
@@ -455,9 +438,8 @@ def _ensure_copyright_string(
     return 1
 
 
-def main():
-    """
-    Entrypoint for the add_copyright hook.
+def main() -> int:
+    """Entrypoint for the add_copyright hook.
 
     Check that source files contain a copyright string, and add one to files that don't.
 
@@ -467,10 +449,7 @@ def main():
     # Build the configuration from config files and CLI args.
     # Fields that appear in both the configuration and CLI args use the CLI
     # values.
-    try:
-        configuration = _read_default_configuration()
-    except KeyError:
-        raise
+    configuration = _read_default_configuration()
     args = _parse_args()
     for key in args:
         if args[key] is not None:
@@ -485,30 +464,29 @@ def main():
     for file in configuration["files"]:
         # Global configurations inherited by this file.
         kwargs: dict = {
-            "format": configuration["format"] or "Copyright (c) {year} {name}",
+            "copyright_format": configuration["format"]
+            or "Copyright (c) {year} {name}",
         }
 
         # Extract the language-specific config options for this file. Override global
         # options where required.
         for tag in identify.tags_from_path(file):
-            if (tag in LANGUAGE_TAGS_TOMLKEYS.keys()) and (
+            if (tag in LANGUAGE_TAGS_TOMLKEYS) and (
                 configuration[LANGUAGE_TAGS_TOMLKEYS[tag]] is not None
             ):
-                for key in configuration[LANGUAGE_TAGS_TOMLKEYS[tag]].keys():
-                    kwargs[key] = configuration[LANGUAGE_TAGS_TOMLKEYS[tag]][key]
+                for key in configuration[LANGUAGE_TAGS_TOMLKEYS[tag]]:
+                    kwargs_key = "copyright_format" if key == "format" else key
+                    kwargs[kwargs_key] = configuration[LANGUAGE_TAGS_TOMLKEYS[tag]][key]
                 break
 
         # Ensure that the file has copyright.
-        try:
-            retv |= _ensure_copyright_string(
-                Path(file),
-                name=configuration["name"],
-                **kwargs,
-            )
-        except (KeyError, ValueError):
-            raise
+        retv |= _ensure_copyright_string(
+            Path(file),
+            name=configuration["name"],
+            **kwargs,
+        )
     return retv
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/src/add_msg_issue_hook/__init__.py
+++ b/src/add_msg_issue_hook/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 """Pre-commit hook for automatically including jira issue ids in commit msg."""

--- a/src/add_msg_issue_hook/add_msg_issue.py
+++ b/src/add_msg_issue_hook/add_msg_issue.py
@@ -2,18 +2,20 @@
 
 # Copyright (c) 2022 - 2026 Benjamin Mummery
 
-"""
-Parse the branch name for anything resembling an issue id, and add it to the commit msg.
+"""Parse the branch name for an issue id and add it to the commit msg.
 
 This module is intended for use as a pre-commit hook. For more information please
 consult the README file.
 """
 
+from __future__ import annotations
+
 import argparse
 import re
 import subprocess
+import sys
 
-from typing import List
+from pathlib import Path
 
 # The default template to use when the commit message has a subject line and body. Can
 # be overridden by the 'format' argument.
@@ -26,12 +28,9 @@ FALLBACK_TEMPLATE: str = "{message}\n[{issue_id}]"
 class BranchNameReadError(BaseException):
     """Raised when the name of the current git branch cannot be read."""
 
-    pass
-
 
 def _get_branch_name() -> str:
-    """
-    Get the name of the current git branch.
+    """Get the name of the current git branch.
 
     Raises:
         BranchNameReadError: when we can't read the name of the current branch.
@@ -46,15 +45,15 @@ def _get_branch_name() -> str:
             universal_newlines=True,
         ).strip()
     except subprocess.CalledProcessError as e:
+        msg = "Getting branch name for add_msg_issue_hook pre-commit hook failed."
         raise BranchNameReadError(
-            "Getting branch name for add_msg_issue_hook pre-commit hook failed.",
+            msg,
         ) from e
     return branch
 
 
-def _get_issue_ids_from_branch_name(branch: str) -> List[str]:
-    """
-    Parse the branch name looking for an issue ID.
+def _get_issue_ids_from_branch_name(branch: str) -> list[str]:
+    """Parse the branch name looking for an issue ID.
 
     Issue IDs are assumed to follow "X-Y" where X is a string of 1-10 letters, and
     Y is a string of 1-5 numerals.
@@ -63,18 +62,16 @@ def _get_issue_ids_from_branch_name(branch: str) -> List[str]:
         branch (str): the name of the current branch.
 
     Returns:
-        str: the first instance of something resembling a jira issue id.
+        list[str]: the first instance of something resembling a jira issue id.
     """
     matches = re.findall("[a-zA-Z]{1,10}-[0-9]{1,5}", branch)
     if len(matches) > 0:
         return [match.upper() for match in matches]
-    else:
-        return []
+    return []
 
 
 def _issue_is_in_message(issue_id: str, message: str) -> bool:
-    """
-    Determine if the issue ID is already in the message.
+    """Determine if the issue ID is already in the message.
 
     Ignores lines in the message that start with '#'.
 
@@ -88,15 +85,11 @@ def _issue_is_in_message(issue_id: str, message: str) -> bool:
     lines = [
         line.strip() for line in message.split("\n") if not line.strip().startswith("#")
     ]
-    for line in lines:
-        if issue_id.lower() in line.lower():
-            return True
-    return False
+    return any(issue_id.lower() in line.lower() for line in lines)
 
 
 def _insert_issue_into_message(issue_id: str, message: str, template: str) -> str:
-    """
-    Insert the issue_id into the commit message according to the template.
+    """Insert the issue_id into the commit message according to the template.
 
     The existing message is parsed into two parts:
     - "Subject" is the first line, if that line is not a comment.
@@ -115,7 +108,7 @@ def _insert_issue_into_message(issue_id: str, message: str, template: str) -> st
         str: the modified message.
     """
     # Separate subject line from message body.
-    content_sections: List[str] = [
+    content_sections: list[str] = [
         line.strip() for line in message.split("\n", maxsplit=1)
     ]
     subject: str = content_sections[0]
@@ -146,11 +139,10 @@ def _insert_issue_into_message(issue_id: str, message: str, template: str) -> st
 
 
 def _parse_args() -> argparse.Namespace:
-    """
-    Parse the CLI arguments.
+    """Parse the CLI arguments.
 
     Returns:
-        argparse.Namespace with the following attributes:
+        argparse.Namespace:
         - commit_msg_filepath (str): path to the location of the commit message
         - template (str): the template into which to render the commit message.
     """
@@ -169,11 +161,14 @@ def _parse_args() -> argparse.Namespace:
 
     for keyword in [r"{subject}", r"{body}", r"{issue_id}"]:
         if keyword not in args.template:
-            raise KeyError(
+            msg = (
                 rf"Template argument '{args.template}' did not contain the required "
                 f"keyword '{keyword}' and cannot be used. "
                 "For more information, see "
-                "https://github.com/BenjaminMummery/pre-commit-hooks",
+                "https://github.com/BenjaminMummery/pre-commit-hooks"
+            )
+            raise KeyError(
+                msg,
             )
 
     try:
@@ -200,11 +195,11 @@ def main() -> int:
         # doing whatever it's trying to do.
         return 0
 
-    issue_ids: List[str] = _get_issue_ids_from_branch_name(branch_name)
+    issue_ids: list[str] = _get_issue_ids_from_branch_name(branch_name)
     if len(issue_ids) < 1:
         return 0  # If no IDs are found, then there's nothing to do
 
-    with open(args.commit_msg_filepath, "r+") as f:
+    with Path(args.commit_msg_filepath).open("r+") as f:
         message: str = f.read()
 
         if _issue_is_in_message(issue_ids[0], message):
@@ -217,4 +212,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/src/americanise_hook/__init__.py
+++ b/src/americanise_hook/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2025 Benjamin Mummery
+# Copyright (c) 2025-2026 Benjamin Mummery
 
 """Pre-commit hook for converting british/canadian/australian spellings to american."""

--- a/src/americanise_hook/americanise.py
+++ b/src/americanise_hook/americanise.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
 # Copyright (c) 2025-2026 Benjamin Mummery
-"""
-Check for non-US spelling in source files, and (optionally) "correct" them.
+"""Check for non-US spelling in source files, and (optionally) "correct" them.
 
 This module is intended for use as a pre-commit hook. For more information please
 consult the README file.
 """
 
+from __future__ import annotations
+
 import argparse
 import re
+import sys
 
 from copy import deepcopy
-from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING
 
 from src._shared import print_diff, resolvers
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 DICTIONARY = {
     # -se -> -ize
@@ -44,9 +48,11 @@ DICTIONARY = {
     "caesium": "cesium",
     # -ce -> -se
     "defence": "defense",
-    # british uses "practice" as the noun and "practise" as the verb. US uses "practice" for both.
+    # British uses "practice" as the noun and "practise" as the verb.
+    # US uses "practice" for both.
     "practise": "practice",
-    # british uses "licence" as the noun and "license" as the verb. US uses "license" for both.
+    # British uses "licence" as the noun and "license" as the verb.
+    # US uses "license" for both.
     "licence": "license",
     # -ge -> -g
     "ageing": "aging",
@@ -72,31 +78,31 @@ def _copy_case(target_string: str, input_string: str) -> str:
     # Identify case
     if target_string.islower():
         return input_string.lower()
-    elif target_string.istitle():
+    if target_string.istitle():
         return input_string.title()
-    elif target_string.isupper():
+    if target_string.isupper():
         return input_string.upper()
-    elif len(target_string) == len(input_string):
+    if len(target_string) == len(input_string):
         input_string_list = list(input_string)
         for i, letter in enumerate(target_string):
             if letter.isupper():
                 input_string_list[i] = input_string[i].upper()
         return "".join(input_string_list)
-    else:
-        input_string_list = list(input_string)
-        for i in range(min([len(target_string), len(input_string)])):
-            if target_string[i].isupper():
-                input_string_list[i] = input_string[i].upper()
-        output_string = "".join(input_string_list)
-        Warning(
-            f"Could not match the case of offending word '{target_string}' - using best guess '{output_string}'.",
-        )
-        return output_string
+    input_string_list = list(input_string)
+    for i in range(min([len(target_string), len(input_string)])):
+        if target_string[i].isupper():
+            input_string_list[i] = input_string[i].upper()
+    output_string = "".join(input_string_list)
+    Warning(
+        f"Could not match the case of offending word '{target_string}' - "
+        f"using best guess '{output_string}'.",
+    )
+    return output_string
 
 
 def _americanise(file: Path, dictionary: dict) -> int:
     """Find common non-US spellings in source files and (optionally) "correct" them."""
-    with open(file, "r+") as f:
+    with file.open("r+") as f:
         old_content: str = f.read()
 
     new_content = old_content.split("\n")
@@ -107,22 +113,30 @@ def _americanise(file: Path, dictionary: dict) -> int:
         if "pragma: no americanise" in line:
             continue
         old_line = deepcopy(line)
-        for key in dictionary:
-            while (match := re.search(key, line, re.IGNORECASE)) is not None:
+        updated_line = line
+        for key, value in dictionary.items():
+            pattern = rf"\b{re.escape(key)}\b"
+            while (
+                match := re.search(pattern, updated_line, re.IGNORECASE)
+            ) is not None:
                 index = match.span()
-                old_word = match.string[index[0] : index[1]]
-                new_word = _copy_case(old_word, dictionary[key])
+                old_word = match.group()
+                new_word = _copy_case(old_word, value)
 
-                line = line[: index[0]] + new_word + line[index[1] :]
+                updated_line = (
+                    updated_line[: index[0]] + new_word + updated_line[index[1] :]
+                )
 
-        if old_line != line:
-            diffs.append(print_diff.format_diff(old_line, line, line_no + 1))
-            new_content[line_no] = line
+        if old_line != updated_line:
+            diffs.append(
+                print_diff.format_diff(old_line, updated_line, line_no + 1),
+            )
+            new_content[line_no] = updated_line
 
     if (output := "\n".join(new_content)) == old_content:
         return 0
 
-    with open(file, "w") as f:
+    with file.open("w") as f:
         f.write(output)
 
     print(file)
@@ -132,8 +146,8 @@ def _americanise(file: Path, dictionary: dict) -> int:
     return 1
 
 
-def _construct_dictionary(word_arg: Union[str, None]) -> dict:
-    """Construct the dict of accepted words from the standard dict and word arguments."""
+def _construct_dictionary(word_arg: str | None) -> dict:
+    """Construct the dict of accepted words from the standard dict and args."""
     if word_arg is None:
         return DICTIONARY
 
@@ -141,22 +155,25 @@ def _construct_dictionary(word_arg: Union[str, None]) -> dict:
 
     custom_dict = {}
     for word in word_arguments:
-        map = [val.lower().strip() for val in word.split(":")]
-        if len(map) != 2:
-            raise ValueError(
-                f"Could not parse word argument '{word_arg}'. Custom word arguments should be a in the format '[incorrect_spelling]:[correct_spelling]', for example 'initialise:initialize'.",
+        mapping = [val.lower().strip() for val in word.split(":")]
+        if len(mapping) != 2:
+            msg = (
+                f"Could not parse word argument '{word_arg}'. Custom word "
+                "arguments should be in the format "
+                "'[incorrect_spelling]:[correct_spelling]', for example "
+                "'initialise:initialize'."
             )
-        custom_dict[map[0]] = map[1]
+            raise ValueError(msg)
+        custom_dict[mapping[0]] = mapping[1]
 
     return {**DICTIONARY, **custom_dict}
 
 
 def _parse_args() -> argparse.Namespace:
-    """
-    Parse the CLI arguments.
+    """Parse the CLI arguments.
 
     Returns:
-        argparse.Namespace with the following attributes:
+        argparse.Namespace:
         - files (list of Path): the paths to each changed file relevant to this hook.
     """
     parser = argparse.ArgumentParser()
@@ -179,11 +196,11 @@ def _parse_args() -> argparse.Namespace:
     return args
 
 
-def main():
-    """
-    Entrypoint for the americanize hook.
+def main() -> int:
+    """Entrypoint for the americanize hook.
 
-    Parses source files looking for common non-american spellings and either corrects or reports them.
+    Parses source files looking for common non-american spellings and either
+    corrects or reports them.
 
     Returns:
         int: 1 if incorrect spellings were found, 0 otherwise.
@@ -199,4 +216,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/src/no_import_testtools_in_src_hook/__init__.py
+++ b/src/no_import_testtools_in_src_hook/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2024 Benjamin Mummery
+# Copyright (c) 2024-2026 Benjamin Mummery
 
 """Pre-commit hook for detecting test-specific imports outside of test files."""

--- a/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
+++ b/src/no_import_testtools_in_src_hook/no_import_testtools_in_src.py
@@ -1,28 +1,31 @@
 # Copyright (c) 2024-2026 Benjamin Mummery
-"""
-Scan source files that aren't tests for test-specific imports (pytest, unittest, etc).
+"""Scan non-test source files for test-specific imports (pytest, unittest, etc).
 
 This module is intended for use as a pre-commit hook. For more information please
 consult the README file.
 """
 
+from __future__ import annotations
+
 import argparse
 import ast
 import logging
+import sys
 
 from collections import namedtuple
-from pathlib import Path
-from typing import Any, Generator, List
+from typing import TYPE_CHECKING, Any, Generator
 
 from src._shared import resolvers
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 Import = namedtuple("Import", ["module", "name", "alias"])
 logger = logging.getLogger(__name__)
 
 
 def _get_imports(file: Path) -> Generator[Import, Any, None]:
-    """
-    Find all modules a file imports.
+    """Find all modules a file imports.
 
     Args:
         file (Path): The file to be checked.
@@ -30,11 +33,11 @@ def _get_imports(file: Path) -> Generator[Import, Any, None]:
     Yields:
         Generator[Import, None]
     """
-    with open(file) as fh:
+    with file.open() as fh:
         try:
             root = ast.parse(fh.read(), file)
         except SyntaxError:
-            logging.warning(
+            logger.warning(
                 f"Could not parse file {file}."
                 " We'll assume that this is fine since an unparsable file probably "
                 "won't successfully import anything anyway.",
@@ -43,7 +46,7 @@ def _get_imports(file: Path) -> Generator[Import, Any, None]:
 
     for node in ast.iter_child_nodes(root):
         if isinstance(node, ast.Import):
-            module: List[str] = []
+            module: list[str] = []
         elif isinstance(node, ast.ImportFrom):
             module = node.module.split(".") if node.module is not None else []
         else:
@@ -55,8 +58,7 @@ def _get_imports(file: Path) -> Generator[Import, Any, None]:
 
 
 def _check_for_imports(file: Path) -> int:
-    """
-    Check whether the file imports from a testing toolkit.
+    """Check whether the file imports from a testing toolkit.
 
     Currently detects imports from pytest and unittest.
 
@@ -66,8 +68,7 @@ def _check_for_imports(file: Path) -> int:
     Returns:
         int: 1 if the file imports testing, 0 otherwise.
     """
-
-    bad_imports: List[str] = []
+    bad_imports: list[str] = []
     test_toolkits = {"pytest", "unittest"}
     for imp in _get_imports(file):
         bad_imports += test_toolkits.intersection(imp.module + imp.name)
@@ -81,11 +82,10 @@ def _check_for_imports(file: Path) -> int:
 
 
 def _parse_args() -> argparse.Namespace:
-    """
-    Parse the CLI arguments.
+    """Parse the CLI arguments.
 
     Returns:
-        argparse.Namespace with the following attributes:
+        argparse.Namespace:
         - files (list of Path): the paths to each changed file relevant to this hook.
     """
     parser = argparse.ArgumentParser()
@@ -99,9 +99,8 @@ def _parse_args() -> argparse.Namespace:
     return args
 
 
-def main():
-    """
-    Entrypoint for the no_import_testtools_in_src hook.
+def main() -> int:
+    """Entrypoint for the no_import_testtools_in_src hook.
 
     Scan source files that aren't tests for test-specific imports (pytest, unittest,
     etc).
@@ -119,4 +118,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/src/sort_file_contents_hook/__init__.py
+++ b/src/sort_file_contents_hook/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 """Pre-commit hook for sorting gitignore files while respecting sections."""

--- a/src/sort_file_contents_hook/sort_file_contents.py
+++ b/src/sort_file_contents_hook/sort_file_contents.py
@@ -1,47 +1,46 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023 - 2026 Benjamin Mummery
-"""
-Sort file contents while preserving section structure.
+"""Sort file contents while preserving section structure.
 
 This module is intended for use as a pre-commit hook. For more information please
 consult the README file.
 """
+
+from __future__ import annotations
 
 import argparse
 import collections
 import itertools
 import typing as t
 
-from pathlib import Path
-
 from src._shared import resolvers
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
 
 
 class UnsortableError(BaseException):
     """Raised when a file cannot be sorted."""
 
-    pass
 
-
-def _sort_lines(lines: t.List[str], unique: bool = False) -> t.List[str]:
-    """
-    Sorts the lines.
+def _sort_lines(lines: list[str], unique: bool = False) -> list[str]:
+    """Sorts the lines.
 
     Arguments:
-        lines (list of str): the lines to be sorted.
+        lines (list[str]): the lines to be sorted.
 
     Keyword Arguments:
         unique (bool): If True, duplicate values will be removed. (default: {False})
 
     Returns:
-        list of str: the sorted lines.
+        list[str]: the sorted lines.
     """
     if unique:
         lines = list(set(lines))
 
-    def _ignore_comments_in_section(input: str) -> str:
+    def _ignore_comments_in_section(text: str) -> str:
         """Key function for sorting section entries."""
-        output = input.strip().lower()
+        output = text.strip().lower()
         if output.startswith("#"):
             output = output[1:].strip()
         return output
@@ -50,21 +49,20 @@ def _sort_lines(lines: t.List[str], unique: bool = False) -> t.List[str]:
 
 
 def _separate_leading_comment(
-    lines: t.List[str],
-) -> t.Tuple[t.Union[t.List[str], None], t.Union[t.List[str], None]]:
-    """
-    Separate a leading comment string or strings from a list of strings.
+    lines: list[str],
+) -> tuple[list[str] | None, list[str] | None]:
+    """Separate a leading comment string or strings from a list of strings.
 
     Arguments:
-        lines (list of str): the lines to be parsed.
+        lines (list[str]): the lines to be parsed.
 
     Returns:
-        list of str (optional), list of str (optional): the list of comment lines and
+        tuple[list[str] | None, list[str] | None]: the list of comment lines and
             sortable lines respectively. If no lines of the specified type were found,
             returns None.
     """
-    comment_lines: t.Optional[t.List[str]] = None
-    sortable_lines: t.Optional[t.List[str]] = None
+    comment_lines: list[str] | None = None
+    sortable_lines: list[str] | None = None
 
     for i, line in enumerate(lines):
         if not line.startswith("#"):
@@ -79,18 +77,17 @@ def _separate_leading_comment(
     return comment_lines, sortable_lines
 
 
-def _identify_sections(lines: t.List[str]) -> t.List[t.List[str]]:
-    """
-    Break down a list of strings into "sections".
+def _identify_sections(lines: list[str]) -> list[list[str]]:
+    """Break down a list of strings into "sections".
 
     Sections are assumed to be a series of one or more lines separated from other
     sections by one or more empty line.
 
     Arguments:
-        lines (list of str): the lines to be parsed.
+        lines (list[str]): the lines to be parsed.
 
     Returns:
-        list of list of str: a list whose entries correspond to the individual
+        list[list[str]]: a list whose entries correspond to the individual
             sections. Each entry contains a list of the lines that make up that section.
     """
     blank_lines = ["\n", ""]
@@ -102,26 +99,25 @@ def _identify_sections(lines: t.List[str]) -> t.List[t.List[str]]:
     # Ensure we have a blank line at the beginning and end:
     _lines = lines
     if _lines[0] not in blank_lines:
-        _lines = ["\n"] + _lines
+        _lines = ["\n", *_lines]
     if _lines[-1] not in blank_lines:
-        _lines = _lines + ["\n"]
+        _lines = [*_lines, "\n"]
 
     # find linebreaks
     linebreaks = [i for i, line in enumerate(_lines) if line in blank_lines]
 
     # Iterate through linebreaks separating out the sections
     sections = []
-    for current, next in zip(linebreaks[0:-1], linebreaks[1:]):
-        if next - current == 1:
+    for current, next_line in zip(linebreaks[0:-1], linebreaks[1:]):
+        if next_line - current == 1:
             continue
-        sections.append(_lines[current + 1 : next])
+        sections.append(_lines[current + 1 : next_line])
 
     return sections
 
 
-def _find_duplicates(lines: t.List[str]) -> t.List[t.Tuple[str, int]]:
-    """
-    Identify duplicate entries in the list.
+def _find_duplicates(lines: list[str]) -> list[tuple[str, int]]:
+    """Identify duplicate entries in the list.
 
     'None' entries are not counted as duplicates.
 
@@ -129,24 +125,22 @@ def _find_duplicates(lines: t.List[str]) -> t.List[t.Tuple[str, int]]:
         lines: the list of strings to check for duplicates.
 
     Returns:
-        list(tuple(str, int)): a list of tuples containing the duplicated string, and
+        list[tuple[str, int]]: a list of tuples containing the duplicated string, and
             the number of instances within the lines.
     """
-    duplicates = [
+    return [
         (item, count) for item, count in collections.Counter(lines).items() if count > 1
     ]
-    return duplicates
 
 
-def _find_comment_clashes(lines: t.List[str]) -> t.List[str]:
-    """
-    Identify duplicate entries in the list where one of the entries is commented out.
+def _find_comment_clashes(lines: list[str]) -> list[str]:
+    """Identify duplicate entries in the list where one of the entries is commented out.
 
     Args:
         lines: the list of strings to check for duplicates.
 
     Returns:
-        list(str): a list of duplicated strings.
+        list[str]: a list of duplicated strings.
     """
     lines = [line.strip(" #") for line in lines]
     duplicates = _find_duplicates(lines)
@@ -155,15 +149,15 @@ def _find_comment_clashes(lines: t.List[str]) -> t.List[str]:
 
 def _sort_contents(file: Path, unique: bool = False) -> int:
     """Sort the contents of the file."""
-    with open(file) as file_obj:
-        lines: t.List[str] = [line.strip("\n") for line in list(file_obj)]
+    with file.open() as file_obj:
+        lines: list[str] = [line.strip("\n") for line in list(file_obj)]
 
     # Identify sections
-    sections: t.List[t.List[str]] = _identify_sections(lines)
+    sections: list[list[str]] = _identify_sections(lines)
 
     # Separate leading comments from sections
-    section_headers: t.List[t.Optional[t.List[str]]] = [None for _ in sections]
-    section_contents: t.List[t.Optional[t.List[str]]] = [None for _ in sections]
+    section_headers: list[list[str] | None] = [None for _ in sections]
+    section_contents: list[list[str] | None] = [None for _ in sections]
     for i, section in enumerate(sections):
         section_headers[i], section_contents[i] = _separate_leading_comment(
             section,
@@ -175,19 +169,19 @@ def _sort_contents(file: Path, unique: bool = False) -> int:
         if section_lines is None:
             continue
 
-        sorted = _sort_lines(section_lines, unique=unique)
+        sorted_lines = _sort_lines(section_lines, unique=unique)
 
         # Skip this section if sorting hasn't changed anything
-        if sorted == section_lines:
+        if sorted_lines == section_lines:
             continue
 
         # Update the section contents
         sections_changed |= True
-        section_contents[i] = sorted
+        section_contents[i] = sorted_lines
 
     # Check for uniqueness
     if unique:
-        duplicates: t.List[t.Tuple[str, int]] = _find_duplicates(
+        duplicates: list[tuple[str, int]] = _find_duplicates(
             list(
                 itertools.chain.from_iterable(
                     [contents for contents in section_contents if contents is not None],
@@ -203,7 +197,7 @@ def _sort_contents(file: Path, unique: bool = False) -> int:
                 err_msg += f"\n- '{item}' appears in {count} sections."
             raise UnsortableError(err_msg)
 
-        comment_clashes: t.List[str] = _find_comment_clashes(
+        comment_clashes: list[str] = _find_comment_clashes(
             list(
                 itertools.chain.from_iterable(
                     [contents for contents in section_contents if contents is not None],
@@ -223,7 +217,7 @@ def _sort_contents(file: Path, unique: bool = False) -> int:
     if not sections_changed:
         return 0
 
-    with open(file, "w") as file_obj:
+    with file.open("w") as file_obj:
         file_obj.write(
             "\n\n".join(
                 [
@@ -241,11 +235,10 @@ def _sort_contents(file: Path, unique: bool = False) -> int:
 
 
 def _parse_args() -> argparse.Namespace:
-    """
-    Parse the CLI arguments.
+    """Parse the CLI arguments.
 
     Returns:
-        argparse.Namespace with the following attributes:
+        argparse.Namespace:
         - files (list of Path): the paths to each changed file relevant to this hook.
         - unique (bool): True if the unique CLI flag was set, False otherwise.
     """
@@ -267,8 +260,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    """
-    Entrypoint for the sort_file_contents hook.
+    """Entrypoint for the sort_file_contents hook.
 
     Identifies sections within the input files by looking for a comment following a
     blank line. The contents of each section are then sorted alphabetically.

--- a/src/sync_type_hints_hook/__init__.py
+++ b/src/sync_type_hints_hook/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025-2026 Benjamin Mummery

--- a/src/sync_type_hints_hook/docstring_types.py
+++ b/src/sync_type_hints_hook/docstring_types.py
@@ -1,0 +1,391 @@
+# Copyright (c) 2025-2026 Benjamin Mummery
+
+"""Parse type information from function and method docstrings."""
+
+from __future__ import annotations
+
+import re
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DocstringTypeInfo:
+    """Type information extracted from a docstring."""
+
+    args: dict[str, str] = field(default_factory=dict)
+    returns: str | None = None
+    style: str | None = None
+
+
+_NUMPY_SECTION_HEADERS = {
+    "parameters",
+    "params",
+    "args",
+    "arguments",
+    "returns",
+    "return",
+    "yields",
+}
+
+
+def _is_numpy_section_start(lines: list[str], index: int) -> bool:
+    if index + 1 >= len(lines):
+        return False
+    header = lines[index].strip().lower()
+    underline = lines[index + 1].strip()
+    return header in _NUMPY_SECTION_HEADERS and bool(re.match(r"^-+$", underline))
+
+
+_SECTION_ALIASES = {
+    "args": "args",
+    "arguments": "args",
+    "parameters": "args",
+    "params": "args",
+    "returns": "returns",
+    "return": "returns",
+    "yields": "returns",
+    "rtype": "returns",
+}
+
+_GOOGLE_PARAM_RE = re.compile(
+    r"^(\s*)(\w+)\s+\(([^)]+)\)\s*:\s*(.*)$",
+)
+_NUMPY_PARAM_RE = re.compile(r"^(\s*)(\w+)\s*:\s*(.+)$")
+_SPHINX_PARAM_RE = re.compile(r"^:param\s+(\S+)\s+(\w+)\s*:\s*(.*)$")
+_SPHINX_TYPE_RE = re.compile(r"^:type\s+(\w+)\s*:\s*(.+)$")
+_SPHINX_RTYPE_RE = re.compile(r"^:rtype:\s*(.+)$")
+
+
+def _normalize_type(type_str: str) -> str:
+    """Normalize a type string for comparison."""
+    normalized = " ".join(type_str.strip().split())
+    if normalized.endswith(", optional"):
+        normalized = normalized[: -len(", optional")].strip()
+    return normalized
+
+
+def types_match(docstring_type: str, signature_type: str) -> bool:
+    """Return True when two type strings describe the same type."""
+    return _normalize_type(docstring_type) == _normalize_type(signature_type)
+
+
+def parse_docstring_types(docstring: str) -> DocstringTypeInfo:
+    """Extract parameter and return types from a docstring.
+
+    Supports Google, NumPy, and Sphinx/reStructuredText formats.
+    """
+    google = _parse_google(docstring)
+    if google.args or google.returns:
+        google.style = "google"
+        return google
+
+    numpy = _parse_numpy(docstring)
+    if numpy.args or numpy.returns:
+        numpy.style = "numpy"
+        return numpy
+
+    sphinx = _parse_sphinx(docstring)
+    if sphinx.args or sphinx.returns:
+        sphinx.style = "sphinx"
+        return sphinx
+
+    return DocstringTypeInfo()
+
+
+def _parse_google(docstring: str) -> DocstringTypeInfo:
+    info = DocstringTypeInfo()
+    section: str | None = None
+
+    for line in docstring.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        header = stripped.rstrip(":")
+        if header.lower() in _SECTION_ALIASES:
+            section = _SECTION_ALIASES[header.lower()]
+            continue
+
+        if section == "args":
+            if match := _GOOGLE_PARAM_RE.match(line):
+                info.args[match.group(2)] = _normalize_type(match.group(3))
+        elif section == "returns" and info.returns is None and ":" in stripped:
+            type_part, _ = stripped.split(":", 1)
+            info.returns = _normalize_type(type_part)
+
+    return info
+
+
+def _parse_numpy(docstring: str) -> DocstringTypeInfo:
+    info = DocstringTypeInfo()
+    lines = docstring.splitlines()
+    index = 0
+
+    while index < len(lines):
+        header = lines[index].strip()
+        if (
+            index + 1 < len(lines)
+            and header.lower() in {"parameters", "params", "args", "arguments"}
+            and re.match(r"^-+$", lines[index + 1].strip())
+        ):
+            index += 2
+            while index < len(lines):
+                line = lines[index]
+                if not line.strip():
+                    index += 1
+                    continue
+                if _is_numpy_section_start(lines, index):
+                    break
+                if match := _NUMPY_PARAM_RE.match(line):
+                    param = match.group(2)
+                    type_str = _normalize_type(match.group(3))
+                    info.args[param] = type_str
+                index += 1
+            continue
+
+        if (
+            index + 1 < len(lines)
+            and header.lower() in {"returns", "return", "yields"}
+            and re.match(r"^-+$", lines[index + 1].strip())
+        ):
+            index += 2
+            if index < len(lines) and lines[index].strip():
+                info.returns = _normalize_type(lines[index].strip())
+            continue
+
+        index += 1
+
+    return info
+
+
+def _parse_sphinx(docstring: str) -> DocstringTypeInfo:
+    info = DocstringTypeInfo()
+    pending_types: dict[str, str] = {}
+
+    for line in docstring.splitlines():
+        stripped = line.strip()
+        if match := _SPHINX_PARAM_RE.match(stripped):
+            type_str, name = match.group(1), match.group(2)
+            info.args[name] = _normalize_type(type_str)
+        elif match := _SPHINX_TYPE_RE.match(stripped):
+            pending_types[match.group(1)] = _normalize_type(match.group(2))
+        elif match := _SPHINX_RTYPE_RE.match(stripped):
+            info.returns = _normalize_type(match.group(1))
+
+    for name, type_str in pending_types.items():
+        info.args.setdefault(name, type_str)
+
+    return info
+
+
+def rewrite_docstring_types(
+    docstring: str,
+    info: DocstringTypeInfo,
+    *,
+    remove_types: bool,
+    updated_args: dict[str, str] | None = None,
+    updated_return: str | None = None,
+) -> tuple[str, bool]:
+    """Rewrite a docstring to remove or update embedded type information.
+
+    Returns:
+        Tuple of the rewritten docstring and whether it changed.
+    """
+    if info.style == "google":
+        return _rewrite_google(
+            docstring,
+            remove_types=remove_types,
+            updated_args=updated_args,
+            updated_return=updated_return,
+        )
+    if info.style == "numpy":
+        return _rewrite_numpy(
+            docstring,
+            remove_types=remove_types,
+            updated_args=updated_args,
+            updated_return=updated_return,
+        )
+    if info.style == "sphinx":
+        return _rewrite_sphinx(
+            docstring,
+            remove_types=remove_types,
+            updated_args=updated_args,
+            updated_return=updated_return,
+        )
+    return docstring, False
+
+
+def _rewrite_google(
+    docstring: str,
+    *,
+    remove_types: bool,
+    updated_args: dict[str, str] | None,
+    updated_return: str | None,
+) -> tuple[str, bool]:
+    section: str | None = None
+    output: list[str] = []
+    changed = False
+
+    for line in docstring.splitlines():
+        stripped = line.strip()
+        header = stripped.rstrip(":")
+        if header.lower() in _SECTION_ALIASES:
+            section = _SECTION_ALIASES[header.lower()]
+            output.append(line)
+            continue
+
+        if section == "args" and (match := _GOOGLE_PARAM_RE.match(line)):
+            indent, name, type_str, description = match.groups()
+            optional_suffix = ", optional" if ", optional" in type_str else ""
+            if updated_args and name in updated_args:
+                type_str = updated_args[name]
+                changed = True
+            if remove_types:
+                output.append(f"{indent}{name}: {description}")
+                changed = True
+            else:
+                output.append(
+                    f"{indent}{name} ({type_str}{optional_suffix}): {description}",
+                )
+            continue
+
+        if section == "returns" and ":" in stripped:
+            indent = line[: len(line) - len(line.lstrip())]
+            type_part, description = stripped.split(":", 1)
+            if updated_return is not None:
+                type_part = updated_return
+                changed = True
+            if remove_types:
+                output.append(f"{indent}{description.lstrip()}")
+                changed = True
+            else:
+                output.append(f"{indent}{type_part}: {description.lstrip()}")
+            section = None
+            continue
+
+        output.append(line)
+
+    return "\n".join(output), changed
+
+
+def _rewrite_numpy(
+    docstring: str,
+    *,
+    remove_types: bool,
+    updated_args: dict[str, str] | None,
+    updated_return: str | None,
+) -> tuple[str, bool]:
+    lines = docstring.splitlines()
+    output: list[str] = []
+    index = 0
+    changed = False
+
+    while index < len(lines):
+        header = lines[index].strip()
+        if (
+            index + 1 < len(lines)
+            and header.lower() in {"parameters", "params", "args", "arguments"}
+            and re.match(r"^-+$", lines[index + 1].strip())
+        ):
+            output.extend([lines[index], lines[index + 1]])
+            index += 2
+            while index < len(lines):
+                line = lines[index]
+                if not line.strip():
+                    output.append(line)
+                    index += 1
+                    continue
+                if _is_numpy_section_start(lines, index):
+                    break
+                if match := _NUMPY_PARAM_RE.match(line):
+                    indent, name, type_str = match.groups()
+                    if updated_args and name in updated_args:
+                        type_str = updated_args[name]
+                        changed = True
+                    if remove_types:
+                        output.append(f"{indent}{name}")
+                        changed = True
+                    else:
+                        output.append(f"{indent}{name} : {type_str}")
+                else:
+                    output.append(line)
+                index += 1
+            continue
+
+        if (
+            index + 1 < len(lines)
+            and header.lower() in {"returns", "return", "yields"}
+            and re.match(r"^-+$", lines[index + 1].strip())
+        ):
+            output.extend([lines[index], lines[index + 1]])
+            index += 2
+            if index < len(lines) and lines[index].strip():
+                type_line = lines[index]
+                if updated_return is not None:
+                    type_line = updated_return
+                    changed = True
+                if remove_types:
+                    index += 1
+                    changed = True
+                else:
+                    output.append(type_line)
+                    index += 1
+            continue
+
+        output.append(lines[index])
+        index += 1
+
+    return "\n".join(output), changed
+
+
+def _rewrite_sphinx(
+    docstring: str,
+    *,
+    remove_types: bool,
+    updated_args: dict[str, str] | None,
+    updated_return: str | None,
+) -> tuple[str, bool]:
+    output: list[str] = []
+    changed = False
+
+    for line in docstring.splitlines():
+        stripped = line.strip()
+        if match := _SPHINX_PARAM_RE.match(stripped):
+            type_str, name, description = match.group(1), match.group(2), match.group(3)
+            if updated_args and name in updated_args:
+                type_str = updated_args[name]
+                changed = True
+            if remove_types:
+                output.append(f":param {name}: {description}")
+                changed = True
+            else:
+                output.append(f":param {type_str} {name}: {description}")
+            continue
+
+        if match := _SPHINX_TYPE_RE.match(stripped):
+            if remove_types:
+                changed = True
+                continue
+            name = match.group(1)
+            type_str = match.group(2)
+            if updated_args and name in updated_args:
+                type_str = updated_args[name]
+                changed = True
+            output.append(f":type {name}: {type_str}")
+            continue
+
+        if match := _SPHINX_RTYPE_RE.match(stripped):
+            type_str = match.group(1)
+            if updated_return is not None:
+                type_str = updated_return
+                changed = True
+            if remove_types:
+                changed = True
+                continue
+            output.append(f":rtype: {type_str}")
+            continue
+
+        output.append(line)
+
+    return "\n".join(output), changed

--- a/src/sync_type_hints_hook/exceptions.py
+++ b/src/sync_type_hints_hook/exceptions.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025-2026 Benjamin Mummery
+
+"""Exceptions raised by the sync-type-hints hook."""
+
+
+class TypeClashError(Exception):
+    """Raised when docstring and signature type information disagree."""
+
+    def __init__(
+        self,
+        file: str,
+        qualified_name: str,
+        parameter: str,
+        docstring_type: str,
+        signature_type: str,
+    ) -> None:
+        self.file = file
+        self.qualified_name = qualified_name
+        self.parameter = parameter
+        self.docstring_type = docstring_type
+        self.signature_type = signature_type
+        super().__init__(
+            f"{file}: {qualified_name}: type clash for '{parameter}': "
+            f"docstring has '{docstring_type}', signature has '{signature_type}'",
+        )

--- a/src/sync_type_hints_hook/signature_types.py
+++ b/src/sync_type_hints_hook/signature_types.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2025-2026 Benjamin Mummery
+
+"""Extract type information from function and method signatures."""
+
+from __future__ import annotations
+
+import ast
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SignatureTypeInfo:
+    """Type information extracted from a function signature."""
+
+    args: dict[str, str | None] = field(default_factory=dict)
+    returns: str | None = None
+
+
+def annotation_to_str(node: ast.expr | None) -> str | None:
+    """Convert an annotation AST node to source text."""
+    if node is None:
+        return None
+    if hasattr(ast, "unparse"):
+        return ast.unparse(node)
+    return _annotation_to_str_legacy(node)
+
+
+def parse_signature_types(node: ast.AST) -> SignatureTypeInfo:
+    """Extract parameter and return annotations from a function node."""
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        msg = "Expected a function definition node."
+        raise TypeError(msg)
+
+    info = SignatureTypeInfo()
+    info.returns = annotation_to_str(node.returns)
+
+    for arg in _iter_arguments(node.args):
+        info.args[arg.arg] = annotation_to_str(arg.annotation)
+
+    return info
+
+
+def _iter_arguments(args: ast.arguments) -> list[ast.arg]:
+    collected: list[ast.arg] = []
+    collected.extend(args.posonlyargs)
+    collected.extend(args.args)
+    if args.vararg is not None:
+        collected.append(args.vararg)
+    collected.extend(args.kwonlyargs)
+    if args.kwarg is not None:
+        collected.append(args.kwarg)
+    return collected
+
+
+def build_signature_edits(
+    node: ast.AST,
+    source: str,
+    *,
+    add_args: dict[str, str],
+    add_return: str | None,
+    overwrite_args: dict[str, str],
+    overwrite_return: str | None,
+) -> list[tuple[int, int, int, int, str]]:
+    """Build source edits for updating a function signature.
+
+    Returns:
+        List of (start_line, start_col, end_line, end_col, replacement) tuples.
+        Line and column numbers are 1-based and 0-based respectively, matching AST.
+    """
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        msg = "Expected a function definition node."
+        raise TypeError(msg)
+
+    edits: list[tuple[int, int, int, int, str]] = []
+
+    for arg in _iter_arguments(node.args):
+        if arg.arg in overwrite_args:
+            edits.extend(_replace_annotation(source, arg, overwrite_args[arg.arg]))
+        elif arg.arg in add_args and arg.annotation is None:
+            edits.extend(_insert_annotation(source, arg, add_args[arg.arg]))
+
+    if overwrite_return is not None and node.returns is not None:
+        edits.extend(_replace_return(source, node, overwrite_return))
+    elif add_return is not None and node.returns is None:
+        edits.extend(_insert_return(source, node, add_return))
+
+    return edits
+
+
+def _insert_annotation(
+    _source: str,
+    arg: ast.arg,
+    type_str: str,
+) -> list[tuple[int, int, int, int, str]]:
+    end_col = arg.col_offset + len(arg.arg)
+    return [
+        (
+            arg.lineno,
+            arg.col_offset,
+            arg.lineno,
+            end_col,
+            f"{arg.arg}: {type_str}",
+        ),
+    ]
+
+
+def _replace_annotation(
+    source: str,
+    arg: ast.arg,
+    type_str: str,
+) -> list[tuple[int, int, int, int, str]]:
+    if arg.annotation is None:
+        return _insert_annotation(source, arg, type_str)
+
+    _node_start_offset(source, arg.lineno, arg.col_offset)
+    end = _node_end_offset(source, arg.annotation)
+    replacement = f"{arg.arg}: {type_str}"
+    start_col = arg.col_offset
+    end_line, end_col = _offset_to_position(source, end)
+    return [(arg.lineno, start_col, end_line, end_col, replacement)]
+
+
+def _insert_return(
+    source: str,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    type_str: str,
+) -> list[tuple[int, int, int, int, str]]:
+    insert_line, insert_col = _arguments_end_position(node, source)
+    return [
+        (insert_line, insert_col, insert_line, insert_col, f" -> {type_str}"),
+    ]
+
+
+def _arguments_end_position(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    source: str,
+) -> tuple[int, int]:
+    end_lineno = getattr(node.args, "end_lineno", None)
+    end_col = getattr(node.args, "end_col_offset", None)
+    if end_lineno is not None and end_col is not None:
+        return end_lineno, end_col
+
+    lines = source.splitlines()
+    line_index = node.lineno - 1
+    paren_depth = 0
+    started = False
+    while line_index < len(lines):
+        for col, char in enumerate(lines[line_index]):
+            if char == "(":
+                paren_depth += 1
+                started = True
+            elif char == ")":
+                paren_depth -= 1
+                if started and paren_depth == 0:
+                    return line_index + 1, col + 1
+        line_index += 1
+
+    msg = f"Could not locate argument list for function '{node.name}'."
+    raise ValueError(msg)
+
+
+def _replace_return(
+    source: str,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    type_str: str,
+) -> list[tuple[int, int, int, int, str]]:
+    if node.returns is None:
+        return _insert_return(source, node, type_str)
+
+    start_line = node.returns.lineno
+    start_col = node.returns.col_offset
+    end_line = node.returns.end_lineno or start_line
+    end_col = node.returns.end_col_offset or start_col
+    return [(start_line, start_col, end_line, end_col, type_str)]
+
+
+def _node_start_offset(source: str, lineno: int, col_offset: int) -> int:
+    lines = source.splitlines(keepends=True)
+    offset = sum(len(lines[i]) for i in range(lineno - 1))
+    return offset + col_offset
+
+
+def _node_end_offset(source: str, node: ast.AST) -> int:
+    end_line_raw = getattr(node, "end_lineno", None)
+    if isinstance(end_line_raw, int):
+        end_line = end_line_raw
+    else:
+        lineno_raw = getattr(node, "lineno", 1)
+        end_line = lineno_raw if isinstance(lineno_raw, int) else 1
+
+    end_col_raw = getattr(node, "end_col_offset", None)
+    if isinstance(end_col_raw, int):
+        end_col = end_col_raw
+    else:
+        end_col = len(source.splitlines()[end_line - 1])
+
+    lines = source.splitlines(keepends=True)
+    offset = sum(len(lines[i]) for i in range(end_line - 1))
+    return offset + end_col
+
+
+def _offset_to_position(source: str, offset: int) -> tuple[int, int]:
+    current = 0
+    for index, line in enumerate(source.splitlines(keepends=True), start=1):
+        next_current = current + len(line)
+        if offset <= next_current:
+            return index, offset - current
+        current = next_current
+    last_line = source.count("\n") + 1
+    return last_line, len(source.splitlines()[-1])
+
+
+def _annotation_to_str_legacy(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+    if isinstance(node, ast.Attribute):
+        return f"{_annotation_to_str_legacy(node.value)}.{node.attr}"
+    if isinstance(node, ast.Subscript):
+        value = _annotation_to_str_legacy(node.value)
+        slice_value = _annotation_to_str_legacy(node.slice)
+        return f"{value}[{slice_value}]"
+    if isinstance(node, ast.Tuple):
+        elements = ", ".join(_annotation_to_str_legacy(elt) for elt in node.elts)
+        if len(node.elts) == 1:
+            elements += ","
+        return f"({elements})"
+    msg = f"Unsupported annotation node: {type(node).__name__}"
+    raise ValueError(msg)

--- a/src/sync_type_hints_hook/source_edits.py
+++ b/src/sync_type_hints_hook/source_edits.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025-2026 Benjamin Mummery
+
+"""Apply ordered text edits to source files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+Edit = Tuple[int, int, int, int, str]
+
+
+@dataclass
+class SourceEdit:
+    """A single replacement in a source file."""
+
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    replacement: str
+
+    @classmethod
+    def from_tuple(cls, edit: Edit) -> SourceEdit:
+        """Create a SourceEdit from a tuple edit descriptor."""
+        start_line, start_col, end_line, end_col, replacement = edit
+        return cls(start_line, start_col, end_line, end_col, replacement)
+
+
+def apply_edits(source: str, edits: Iterable[Edit]) -> str:
+    """Apply edits from bottom to top so offsets remain valid."""
+    line_starts = _line_starts(source)
+    normalized = sorted(
+        [SourceEdit.from_tuple(edit) for edit in edits],
+        key=lambda edit: (
+            _position_to_index(line_starts, edit.end_line, edit.end_col),
+            _position_to_index(line_starts, edit.start_line, edit.start_col),
+        ),
+        reverse=True,
+    )
+
+    for edit in normalized:
+        start_index = _position_to_index(line_starts, edit.start_line, edit.start_col)
+        end_index = _position_to_index(line_starts, edit.end_line, edit.end_col)
+        source = source[:start_index] + edit.replacement + source[end_index:]
+
+    return source
+
+
+def _line_starts(source: str) -> list[int]:
+    starts = [0]
+    for index, character in enumerate(source):
+        if character == "\n":
+            starts.append(index + 1)
+    return starts
+
+
+def _position_to_index(line_starts: list[int], lineno: int, col_offset: int) -> int:
+    if lineno <= 0 or lineno > len(line_starts):
+        msg = f"Line number {lineno} is out of range."
+        raise IndexError(msg)
+    return line_starts[lineno - 1] + col_offset

--- a/src/sync_type_hints_hook/sync_type_hints.py
+++ b/src/sync_type_hints_hook/sync_type_hints.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026 Benjamin Mummery
+"""Synchronise type hints between function signatures and docstrings.
+
+This module is intended for use as a pre-commit hook. For more information please
+consult the README file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable
+
+from src._shared import print_diff, resolvers
+from src._shared.config_parsing import read_config
+from src.sync_type_hints_hook.docstring_types import (
+    parse_docstring_types,
+    rewrite_docstring_types,
+    types_match,
+)
+from src.sync_type_hints_hook.exceptions import TypeClashError
+from src.sync_type_hints_hook.signature_types import (
+    build_signature_edits,
+    parse_signature_types,
+)
+from src.sync_type_hints_hook.source_edits import apply_edits
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.sync_type_hints_hook.source_edits import Edit
+
+TOOL_NAME = "sync_type_hints"
+IGNORE_PRAGMA = "pragma: no sync-type-hints"
+
+
+@dataclass
+class FunctionContext:
+    """Metadata for a function or method to be processed."""
+
+    node: ast.AST
+    qualified_name: str
+
+
+@dataclass
+class HookConfig:
+    """Runtime configuration for the sync-type-hints hook."""
+
+    on_clash: str = "error"
+    remove_docstring_types: bool = False
+
+
+def _parse_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes", "on"}
+    msg = f"Could not parse boolean config value '{value}'."
+    raise ValueError(msg)
+
+
+def _load_config() -> HookConfig:
+    try:
+        config, _ = read_config(TOOL_NAME)
+    except FileNotFoundError:
+        return HookConfig()
+
+    on_clash = str(config.get("on-clash", config.get("on_clash", "error")))
+    remove_docstring_types = _parse_bool(
+        config.get(
+            "remove-docstring-types",
+            config.get("remove_docstring_types", False),
+        ),
+    )
+    return HookConfig(
+        on_clash=on_clash,
+        remove_docstring_types=remove_docstring_types,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*", default=[])
+    parser.add_argument(
+        "--on-clash",
+        choices=["error", "prefer-signature", "prefer-docstring"],
+        default=None,
+    )
+    parser.add_argument(
+        "--remove-docstring-types",
+        action="store_true",
+        default=None,
+    )
+
+    args = parser.parse_args()
+    args.files = resolvers.resolve_files(args.files)
+
+    config = _load_config()
+    if args.on_clash is None:
+        args.on_clash = config.on_clash
+    if args.remove_docstring_types is None:
+        args.remove_docstring_types = config.remove_docstring_types
+
+    return args
+
+
+def _should_ignore(source: str, node: ast.AST) -> bool:
+    if not hasattr(node, "lineno"):
+        return False
+    lines = source.splitlines()
+    if node.lineno - 1 >= len(lines):
+        return False
+    return IGNORE_PRAGMA in lines[node.lineno - 1]
+
+
+def _get_docstring_node(node: ast.AST) -> tuple[ast.expr, str] | None:
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return None
+    if not node.body:
+        return None
+    statement = node.body[0]
+    if not isinstance(statement, ast.Expr):
+        return None
+    value = statement.value
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return value, value.value
+    if isinstance(value, ast.Str):  # pragma: no cover
+        return value, value.s  # type: ignore[return-value]
+    return None
+
+
+def _docstring_edit(source: str, doc_node: ast.expr, new_doc: str) -> Edit:
+    start = _node_start_offset(source, doc_node.lineno, doc_node.col_offset)
+    prefix = source[start : start + 3]
+    quote = prefix if prefix in {'"""', "'''"} else '"""'
+    end_line = doc_node.end_lineno or doc_node.lineno
+    end_col = doc_node.end_col_offset or doc_node.col_offset
+    replacement = f"{quote}{new_doc}{quote}"
+    return (
+        doc_node.lineno,
+        doc_node.col_offset,
+        end_line,
+        end_col,
+        replacement,
+    )
+
+
+def _node_start_offset(source: str, lineno: int, col_offset: int) -> int:
+    lines = source.splitlines(keepends=True)
+    offset = sum(len(lines[i]) for i in range(lineno - 1))
+    return offset + col_offset
+
+
+class _FunctionCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.functions: list[FunctionContext] = []
+        self._parents: list[str] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._parents.append(node.name)
+        self.generic_visit(node)
+        self._parents.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        qualified_name = ".".join([*self._parents, node.name])
+        self.functions.append(FunctionContext(node=node, qualified_name=qualified_name))
+        self._parents.append(node.name)
+        self.generic_visit(node)
+        self._parents.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.visit_FunctionDef(node)  # type: ignore[arg-type]
+
+
+def _collect_functions(tree: ast.AST) -> list[FunctionContext]:
+    collector = _FunctionCollector()
+    collector.visit(tree)
+    return collector.functions
+
+
+def _plan_function_edits(
+    source: str,
+    context: FunctionContext,
+    file: Path,
+    config: HookConfig,
+) -> tuple[list[Edit], bool]:
+    node = context.node
+    if _should_ignore(source, node):
+        return [], False
+
+    docstring_info = _get_docstring_node(node)
+    if docstring_info is None:
+        return [], False
+
+    doc_node, docstring = docstring_info
+    doc_types = parse_docstring_types(docstring)
+    if not doc_types.args and doc_types.returns is None:
+        return [], False
+
+    signature_types = parse_signature_types(node)
+
+    add_args: dict[str, str] = {}
+    overwrite_args: dict[str, str] = {}
+    updated_doc_args: dict[str, str] = {}
+    add_return: str | None = None
+    overwrite_return: str | None = None
+    updated_doc_return: str | None = None
+
+    for name, doc_type in doc_types.args.items():
+        signature_type = signature_types.args.get(name)
+        if signature_type is None:
+            add_args[name] = doc_type
+            continue
+
+        if types_match(doc_type, signature_type):
+            continue
+
+        if config.on_clash == "error":
+            raise TypeClashError(
+                str(file),
+                context.qualified_name,
+                name,
+                doc_type,
+                signature_type,
+            )
+        if config.on_clash == "prefer-signature":
+            updated_doc_args[name] = signature_type
+        else:
+            overwrite_args[name] = doc_type
+
+    if doc_types.returns is not None:
+        if signature_types.returns is None:
+            add_return = doc_types.returns
+        elif not types_match(doc_types.returns, signature_types.returns):
+            if config.on_clash == "error":
+                raise TypeClashError(
+                    str(file),
+                    context.qualified_name,
+                    "return",
+                    doc_types.returns,
+                    signature_types.returns,
+                )
+            if config.on_clash == "prefer-signature":
+                updated_doc_return = signature_types.returns
+            else:
+                overwrite_return = doc_types.returns
+    elif signature_types.returns is not None and config.on_clash == "prefer-docstring":
+        updated_doc_return = signature_types.returns
+
+    edits = build_signature_edits(
+        node,
+        source,
+        add_args=add_args,
+        add_return=add_return,
+        overwrite_args=overwrite_args,
+        overwrite_return=overwrite_return,
+    )
+
+    docstring_changed = False
+    if (
+        config.remove_docstring_types
+        or updated_doc_args
+        or updated_doc_return is not None
+    ):
+        new_docstring, docstring_changed = rewrite_docstring_types(
+            docstring,
+            doc_types,
+            remove_types=config.remove_docstring_types,
+            updated_args=updated_doc_args or None,
+            updated_return=updated_doc_return,
+        )
+        if docstring_changed:
+            edits.append(_docstring_edit(source, doc_node, new_docstring))
+
+    return edits, bool(edits)
+
+
+def _format_edit_messages(
+    source: str, new_source: str, edits: Iterable[Edit]
+) -> list[str]:
+    messages: list[str] = []
+    old_lines = source.splitlines()
+    new_lines = new_source.splitlines()
+    seen_lines = set()
+
+    for edit in edits:
+        start_line = edit[0]
+        if start_line in seen_lines:
+            continue
+        if start_line - 1 >= len(old_lines) or start_line - 1 >= len(new_lines):
+            continue
+        old_line = old_lines[start_line - 1]
+        new_line = new_lines[start_line - 1]
+        if old_line != new_line:
+            messages.append(print_diff.format_diff(old_line, new_line, start_line))
+            seen_lines.add(start_line)
+
+    return messages
+
+
+def _sync_type_hints(file: Path, config: HookConfig) -> int:
+    with file.open() as handle:
+        source = handle.read()
+
+    try:
+        tree = ast.parse(source, filename=str(file))
+    except SyntaxError as error:
+        print(f"{file}: could not parse file: {error}", file=sys.stderr)
+        return 1
+
+    all_edits: list[Edit] = []
+
+    try:
+        for context in _collect_functions(tree):
+            edits, _ = _plan_function_edits(source, context, file, config)
+            all_edits.extend(edits)
+    except TypeClashError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    if not all_edits:
+        return 0
+
+    new_source = apply_edits(source, all_edits)
+    if new_source == source:
+        return 0
+
+    with file.open("w") as handle:
+        handle.write(new_source)
+
+    print(file)
+    for message in _format_edit_messages(source, new_source, all_edits):
+        print(message)
+
+    return 1
+
+
+def main() -> int:
+    """Entrypoint for the sync-type-hints hook."""
+    args = _parse_args()
+    retv = 0
+    for file in args.files:
+        config = HookConfig(
+            on_clash=args.on_clash,
+            remove_docstring_types=args.remove_docstring_types,
+        )
+        retv |= _sync_type_hints(file, config)
+    return retv
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sync_type_hints_hook/test_sync_type_hints.py
+++ b/src/sync_type_hints_hook/test_sync_type_hints.py
@@ -1,0 +1,376 @@
+# Copyright (c) 2025-2026 Benjamin Mummery
+
+import ast
+import textwrap
+
+import pytest
+
+from src.sync_type_hints_hook.docstring_types import (
+    parse_docstring_types,
+    rewrite_docstring_types,
+    types_match,
+)
+from src.sync_type_hints_hook.exceptions import TypeClashError
+from src.sync_type_hints_hook.signature_types import (
+    annotation_to_str,
+    build_signature_edits,
+    parse_signature_types,
+)
+from src.sync_type_hints_hook.source_edits import apply_edits
+from src.sync_type_hints_hook.sync_type_hints import (
+    HookConfig,
+    _collect_functions,
+    _get_docstring_node,
+    _load_config,
+    _plan_function_edits,
+    _sync_type_hints,
+)
+
+
+class TestParseGoogleDocstrings:
+    @staticmethod
+    def test_extracts_args_and_returns():
+        docstring = (
+            "Do something.\n\n"
+            "Args:\n"
+            "    name (str): The name.\n"
+            "    count (int, optional): The count.\n\n"
+            "Returns:\n"
+            "    bool: Whether it worked.\n"
+        )
+        info = parse_docstring_types(docstring)
+        assert info.style == "google"
+        assert info.args == {"name": "str", "count": "int"}
+        assert info.returns == "bool"
+
+
+class TestParseNumpyDocstrings:
+    @staticmethod
+    def test_extracts_args_and_returns():
+        docstring = (
+            "Do something.\n\n"
+            "Parameters\n"
+            "----------\n"
+            "name : str\n"
+            "    The name.\n"
+            "count : int\n"
+            "    The count.\n\n"
+            "Returns\n"
+            "-------\n"
+            "bool\n"
+            "    Whether it worked.\n"
+        )
+        info = parse_docstring_types(docstring)
+        assert info.style == "numpy"
+        assert info.args == {"name": "str", "count": "int"}
+        assert info.returns == "bool"
+
+
+class TestParseSphinxDocstrings:
+    @staticmethod
+    def test_extracts_args_and_returns():
+        docstring = (
+            "Do something.\n\n"
+            ":param str name: The name.\n"
+            ":param int count: The count.\n"
+            ":rtype: bool\n"
+        )
+        info = parse_docstring_types(docstring)
+        assert info.style == "sphinx"
+        assert info.args == {"name": "str", "count": "int"}
+        assert info.returns == "bool"
+
+    @staticmethod
+    def test_supports_type_directives():
+        docstring = ":type name: str\n:type count: int\n:rtype: bool\n"
+        info = parse_docstring_types(docstring)
+        assert info.style == "sphinx"
+        assert info.args == {"name": "str", "count": "int"}
+        assert info.returns == "bool"
+
+
+class TestTypesMatch:
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("left", "right", "expected"),
+        [
+            ("str", "str", True),
+            ("int", "str", False),
+            ("Optional[str]", "Optional[str]", True),
+            ("int, optional", "int", True),
+        ],
+    )
+    def test_normalizes_types(left, right, expected):
+        assert types_match(left, right) is expected
+
+
+class TestRewriteDocstrings:
+    @staticmethod
+    def test_remove_google_types():
+        docstring = (
+            "Summary.\n\n"
+            "Args:\n"
+            "    name (str): The name.\n\n"
+            "Returns:\n"
+            "    bool: Whether it worked.\n"
+        )
+        info = parse_docstring_types(docstring)
+        rewritten, changed = rewrite_docstring_types(
+            docstring,
+            info,
+            remove_types=True,
+        )
+        assert changed is True
+        assert "(str)" not in rewritten
+        assert "name: The name." in rewritten
+        assert "Whether it worked." in rewritten
+
+    @staticmethod
+    def test_update_google_types():
+        docstring = "Args:\n    name (str): The name.\n"
+        info = parse_docstring_types(docstring)
+        rewritten, changed = rewrite_docstring_types(
+            docstring,
+            info,
+            remove_types=False,
+            updated_args={"name": "int"},
+        )
+        assert changed is True
+        assert "name (int): The name." in rewritten
+
+    @staticmethod
+    def test_remove_numpy_types():
+        docstring = (
+            "Parameters\n"
+            "----------\n"
+            "name : str\n"
+            "    The name.\n\n"
+            "Returns\n"
+            "-------\n"
+            "bool\n"
+            "    Whether it worked.\n"
+        )
+        info = parse_docstring_types(docstring)
+        rewritten, changed = rewrite_docstring_types(
+            docstring,
+            info,
+            remove_types=True,
+        )
+        assert changed is True
+        assert "name : str" not in rewritten
+        assert "name\n" in rewritten
+
+    @staticmethod
+    def test_remove_sphinx_types():
+        docstring = ":param str name: The name.\n:rtype: bool\n"
+        info = parse_docstring_types(docstring)
+        rewritten, changed = rewrite_docstring_types(
+            docstring,
+            info,
+            remove_types=True,
+        )
+        assert changed is True
+        assert ":param name: The name." in rewritten
+        assert ":rtype:" not in rewritten
+
+
+class TestSignatureTypes:
+    @staticmethod
+    def test_parse_and_build_edits():
+        source = textwrap.dedent(
+            """
+            def foo(name, count=1):
+                '''Doc.'''
+                return True
+            """,
+        ).strip()
+        tree = ast.parse(source)
+        node = tree.body[0]
+        signature = parse_signature_types(node)
+        assert signature.args == {"name": None, "count": None}
+        assert signature.returns is None
+
+        edits = build_signature_edits(
+            node,
+            source,
+            add_args={"name": "str", "count": "int"},
+            add_return="bool",
+            overwrite_args={},
+            overwrite_return=None,
+        )
+        updated = apply_edits(source, edits)
+        assert "name: str" in updated
+        assert "count: int" in updated
+        assert "-> bool:" in updated
+
+    @staticmethod
+    def test_replace_existing_annotations():
+        source = "def foo(name: str) -> bool:\n    pass\n"
+        node = ast.parse(source).body[0]
+        edits = build_signature_edits(
+            node,
+            source,
+            add_args={},
+            add_return=None,
+            overwrite_args={"name": "int"},
+            overwrite_return="str",
+        )
+        updated = apply_edits(source, edits)
+        assert updated == "def foo(name: int) -> str:\n    pass\n"
+
+    @staticmethod
+    def test_multiline_signature_return_insert():
+        source = "def foo(\n    name,\n):\n    pass\n"
+        node = ast.parse(source).body[0]
+        edits = build_signature_edits(
+            node,
+            source,
+            add_args={"name": "str"},
+            add_return="bool",
+            overwrite_args={},
+            overwrite_return=None,
+        )
+        updated = apply_edits(source, edits)
+        assert "name: str" in updated
+        assert ") -> bool:" in updated
+
+    @staticmethod
+    def test_annotation_to_str_for_subscript():
+        func = ast.parse("def foo(x: Optional[str]) -> None: ...").body[0]
+        assert isinstance(func, ast.FunctionDef)
+        assert annotation_to_str(func.args.args[0].annotation) == "Optional[str]"
+
+
+class TestApplyEdits:
+    @staticmethod
+    def test_applies_multiple_edits():
+        source = "def foo(x, y):\n    pass\n"
+        edits = [(1, 8, 1, 9, "x: str"), (1, 11, 1, 12, "y: int")]
+        assert apply_edits(source, edits) == "def foo(x: str, y: int):\n    pass\n"
+
+    @staticmethod
+    def test_rejects_invalid_line_number():
+        with pytest.raises(IndexError):
+            apply_edits("x = 1\n", [(99, 0, 99, 1, "y")])
+
+
+class TestSyncTypeHintsHelpers:
+    @staticmethod
+    def test_collect_functions_in_classes():
+        source = textwrap.dedent(
+            """
+            class Example:
+                def method(self):
+                    pass
+            """,
+        ).strip()
+        tree = ast.parse(source)
+        functions = _collect_functions(tree)
+        assert len(functions) == 1
+        assert functions[0].qualified_name == "Example.method"
+
+    @staticmethod
+    def test_get_docstring_node():
+        source = 'def foo():\n    """Doc."""\n    pass\n'
+        node = ast.parse(source).body[0]
+        docstring = _get_docstring_node(node)
+        assert docstring is not None
+        assert docstring[1] == "Doc."
+
+    @staticmethod
+    def test_plan_function_edits_prefers_docstring(tmp_path):
+        source = textwrap.dedent(
+            """
+            def foo(name: int) -> bool:
+                '''Summary.
+
+                Args:
+                    name (str): The name.
+                '''
+                return True
+            """,
+        ).strip()
+        file = tmp_path / "example.py"
+        tree = ast.parse(source)
+        context = _collect_functions(tree)[0]
+        edits, changed = _plan_function_edits(
+            source,
+            context,
+            file,
+            HookConfig(on_clash="prefer-docstring"),
+        )
+        assert changed is True
+        updated = apply_edits(source, edits)
+        assert "name: str" in updated
+
+    @staticmethod
+    def test_plan_function_raises_on_clash(tmp_path):
+        source = textwrap.dedent(
+            """
+            def foo(name: int):
+                '''Summary.
+
+                Args:
+                    name (str): The name.
+                '''
+                return True
+            """,
+        ).strip()
+        file = tmp_path / "example.py"
+        tree = ast.parse(source)
+        context = _collect_functions(tree)[0]
+        with pytest.raises(TypeClashError):
+            _plan_function_edits(
+                source,
+                context,
+                file,
+                HookConfig(on_clash="error"),
+            )
+
+    @staticmethod
+    def test_sync_type_hints_syntax_error(tmp_path, capsys):
+        file = tmp_path / "broken.py"
+        file.write_text("def broken(:\n")
+        assert _sync_type_hints(file, HookConfig()) == 1
+        captured = capsys.readouterr()
+        assert "could not parse file" in captured.err
+
+    @staticmethod
+    def test_sync_type_hints_ignore_pragma(tmp_path):
+        source = textwrap.dedent(
+            """
+            def foo(name):  # pragma: no sync-type-hints
+                '''Args:
+                    name (str): The name.
+                '''
+                return name
+            """,
+        ).strip()
+        file = tmp_path / "ignored.py"
+        file.write_text(source)
+        assert _sync_type_hints(file, HookConfig()) == 0
+
+    @staticmethod
+    def test_load_config_without_file(monkeypatch):
+        monkeypatch.chdir("/tmp")
+        assert _load_config() == HookConfig()
+
+    @staticmethod
+    def test_load_config_from_pyproject(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.sync_type_hints]\n"
+            'on-clash = "prefer-signature"\n'
+            "remove-docstring-types = true\n",
+        )
+        config = _load_config()
+        assert config.on_clash == "prefer-signature"
+        assert config.remove_docstring_types is True
+
+
+class TestTypeClashError:
+    @staticmethod
+    def test_message():
+        error = TypeClashError("file.py", "foo", "x", "str", "int")
+        assert "docstring has 'str'" in str(error)
+        assert "signature has 'int'" in str(error)

--- a/src/update_copyright_hook/__init__.py
+++ b/src/update_copyright_hook/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 """Pre-commit hook for updating dates on copyright comments."""

--- a/src/update_copyright_hook/update_copyright.py
+++ b/src/update_copyright_hook/update_copyright.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023 - 2026 Benjamin Mummery
-"""
-Scan source files for anything resembling a copyright string, updating dates.
+"""Scan source files for anything resembling a copyright string, updating dates.
 
 This module is intended for use as a pre-commit hook. For more information please
 consult the README file.
 """
 
+from __future__ import annotations
+
 import argparse
 import datetime
+import sys
 
-from pathlib import Path
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING
 
 from src._shared import print_diff, resolvers
 from src._shared.comment_mapping import get_comment_markers
@@ -20,23 +21,25 @@ from src._shared.copyright_parsing import (
     parse_copyright_docstring,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 def _update_copyright_dates(file: Path) -> int:
-    """
-    Ensure that if the file has a copyright string, the end date matches the current year.
+    """Ensure the file copyright end date matches the current year.
 
     This function encompasses the heavy lifting for the hook.
 
     Args:
-        file (path): the file to be checked.
+        file (Path): the file to be checked.
 
     Returns:
         int: 0 if the file already had an up to date copyright string or had no
             copyright string, 1 if a copyright string had to be added.
     """
-    with open(file, "r+") as f:
+    with file.open("r+") as f:
         content: str = f.read()
-        comment_markers: Tuple[str, Optional[str]] = get_comment_markers(file)
+        comment_markers: tuple[str, str | None] = get_comment_markers(file)
 
         # Early return for no copyright string in file
         if not (
@@ -83,11 +86,10 @@ def _update_copyright_dates(file: Path) -> int:
 
 
 def _parse_args() -> argparse.Namespace:
-    """
-    Parse the CLI arguments.
+    """Parse the CLI arguments.
 
     Returns:
-        argparse.Namespace with the following attributes:
+        argparse.Namespace:
         - files (list of Path): the paths to each changed file relevant to this hook.
     """
     parser = argparse.ArgumentParser()
@@ -101,9 +103,8 @@ def _parse_args() -> argparse.Namespace:
     return args
 
 
-def main():
-    """
-    Entrypoint for the update_copyright hook.
+def main() -> int:
+    """Entrypoint for the update_copyright hook.
 
     Parses source files containing a copyright string, and updates the date range if it
     falls short of the current year.
@@ -121,4 +122,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2022 - 2023 Benjamin Mummery
+# Copyright (c) 2022 - 2026 Benjamin Mummery
 
 """Required for sharing utilities across test files."""

--- a/tests/add_copyright_hook/__init__.py
+++ b/tests/add_copyright_hook/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery

--- a/tests/add_copyright_hook/test_integration_add_copyright.py
+++ b/tests/add_copyright_hook/test_integration_add_copyright.py
@@ -1240,7 +1240,7 @@ class TestFailureStates:
                 write_config_file(
                     git_repo.workspace,
                     config_file,
-                    f'[tool.add_copyright.{language.toml_key}]\nformat="{input_format}"\n',  # noqa: E501
+                    f'[tool.add_copyright.{language.toml_key}]\nformat="{input_format}"\n',
                 )
 
                 # WHEN
@@ -1364,9 +1364,8 @@ class TestFailureStates:
             )
 
             # WHEN
-            with cwd(git_repo.workspace):
-                with pytest.raises(ValueError) as e:
-                    add_copyright.main()
+            with cwd(git_repo.workspace), pytest.raises(ValueError) as e:
+                add_copyright.main()
 
             # THEN
             assert_matching(
@@ -1419,9 +1418,8 @@ class TestFailureStates:
             )
 
             # WHEN
-            with cwd(git_repo.workspace):
-                with pytest.raises(ValueError) as e:
-                    add_copyright.main()
+            with cwd(git_repo.workspace), pytest.raises(ValueError) as e:
+                add_copyright.main()
 
             # THEN
             assert e.exconly().startswith(
@@ -1442,12 +1440,11 @@ class TestGitRepoErrors:
         files = [f"hello{language.extension}"]
         for file in files:
             (tmp_path / file).write_text("")
-        mocker.patch("sys.argv", ["stub_name"] + files)
+        mocker.patch("sys.argv", ["stub_name", *files])
 
         # WHEN / THEN
-        with cwd(tmp_path):
-            with pytest.raises(InvalidGitRepositoryError):
-                add_copyright.main()
+        with cwd(tmp_path), pytest.raises(InvalidGitRepositoryError):
+            add_copyright.main()
 
     @staticmethod
     @pytest.mark.parametrize("language", CopyrightGlobals.SUPPORTED_LANGUAGES)
@@ -1478,8 +1475,7 @@ class TestGitRepoErrors:
         git_repo.run('git config user.name ""')
 
         # WHEN / THEN
-        with cwd(git_repo.workspace):
-            with pytest.raises(ValueError) as e:
-                add_copyright.main()
+        with cwd(git_repo.workspace), pytest.raises(ValueError) as e:
+            add_copyright.main()
 
         assert e.exconly() == "ValueError: The git username is not configured."

--- a/tests/add_copyright_hook/test_integration_add_copyright.py
+++ b/tests/add_copyright_hook/test_integration_add_copyright.py
@@ -8,6 +8,8 @@ from pytest import CaptureFixture
 from pytest_git import GitRepo
 from pytest_mock import MockerFixture
 
+from git import InvalidGitRepositoryError
+
 from conftest import (
     CopyrightGlobals,
     DocstrSupportedLanguage,
@@ -19,7 +21,6 @@ from conftest import (
 )
 from src._shared.exceptions import InvalidConfigError
 from src.add_copyright_hook import add_copyright
-from src.add_copyright_hook.add_copyright import InvalidGitRepositoryError
 
 
 class TestMeta:

--- a/tests/add_copyright_hook/test_system_add_copyright.py
+++ b/tests/add_copyright_hook/test_system_add_copyright.py
@@ -432,7 +432,7 @@ class TestCustomBehavior:
 
                 toml_text = "\n".join(
                     [
-                        f'[tool.add_copyright.{lang.toml_key}]\nformat="""{lang.custom_copyright_format_commented}"""\n'  # noqa: E501
+                        f'[tool.add_copyright.{lang.toml_key}]\nformat="""{lang.custom_copyright_format_commented}"""\n'
                         for lang in CopyrightGlobals.SUPPORTED_LANGUAGES
                     ],
                 )
@@ -490,7 +490,7 @@ class TestCustomBehavior:
                 for language in CopyrightGlobals.SUPPORTED_LANGUAGES:
                     toml_text += (
                         f"[tool.add_copyright.{language.toml_key}]\n"
-                        f'format="""{language.custom_copyright_format_uncommented}"""\n\n'  # noqa: E501
+                        f'format="""{language.custom_copyright_format_uncommented}"""\n\n'
                     )
                 write_config_file(
                     git_repo.workspace,

--- a/tests/add_msg_issue_hook/__init__.py
+++ b/tests/add_msg_issue_hook/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery

--- a/tests/add_msg_issue_hook/test_integration_add_msg_issue.py
+++ b/tests/add_msg_issue_hook/test_integration_add_msg_issue.py
@@ -1,14 +1,18 @@
 # Copyright (c) 2023 - 2026 Benjamin Mummery
-from pathlib import Path
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 
-from pytest_git import GitRepo
-from pytest_mock import MockerFixture
-
 from conftest import assert_matching
 from src.add_msg_issue_hook import add_msg_issue
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_git import GitRepo
+    from pytest_mock import MockerFixture
 
 BRANCH_NAMES = [
     ("ORQSDK-3", "ORQSDK-3"),
@@ -297,7 +301,7 @@ class TestFailureStates:
     def test_missing_key_in_template(
         cwd,
         template: str,
-        missing_keys: List[str],
+        missing_keys: list[str],
         tmp_path: Path,
         mocker: MockerFixture,
         capsys: pytest.CaptureFixture,
@@ -314,16 +318,15 @@ class TestFailureStates:
         )
 
         # WHEN
-        with cwd(tmp_path):
-            with pytest.raises(KeyError) as e:
-                add_msg_issue.main()
+        with cwd(tmp_path), pytest.raises(KeyError) as e:
+            add_msg_issue.main()
 
         # THEN
         expected_errormessage: str = (
             f"KeyError: \"Template argument {template!r} did not contain the required keyword '"  # noqa: E501
-            + "{"
+             "{"
             + missing_keys[0]
-            + "}' and cannot be used. For more information, see https://github.com/BenjaminMummery/pre-commit-hooks\""  # noqa: E501
+            + "}' and cannot be used. For more information, see https://github.com/BenjaminMummery/pre-commit-hooks\""
         )
         assert_matching(
             "captured err",
@@ -340,7 +343,7 @@ class TestFailureStates:
     def test_additional_key_in_template(
         cwd,
         template: str,
-        additional_keys: List[str],
+        additional_keys: list[str],
         tmp_path: Path,
         mocker: MockerFixture,
         capsys: pytest.CaptureFixture,
@@ -357,9 +360,8 @@ class TestFailureStates:
         )
 
         # WHEN
-        with cwd(tmp_path):
-            with pytest.raises(KeyError) as e:
-                add_msg_issue.main()
+        with cwd(tmp_path), pytest.raises(KeyError) as e:
+            add_msg_issue.main()
 
         # THEN
         assert_matching(

--- a/tests/add_msg_issue_hook/test_system_add_msg_issue.py
+++ b/tests/add_msg_issue_hook/test_system_add_msg_issue.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 pass

--- a/tests/americanise_hook/test_integration_americanise.py
+++ b/tests/americanise_hook/test_integration_americanise.py
@@ -18,7 +18,7 @@ ARMOUR = True
 
 CoLoUr = False
 
-x = deInitIalise()
+initialise = True
 """
 
 us_file_content = """def initialize():
@@ -32,7 +32,7 @@ ARMOR = True
 
 CoLoR = False
 
-x = deInitIalize()
+initialize = True
 """
 
 expected_reports_full = [
@@ -40,7 +40,7 @@ expected_reports_full = [
     "  line 4:\n  - class Instantiater:\n  + class Instantiator:",
     "  line 8:\n  - ARMOUR = True\n  + ARMOR = True",
     "  line 10:\n  - CoLoUr = False\n  + CoLoR = False",
-    "  line 12:\n  - x = deInitIalise()\n  + x = deInitIalize()",
+    "  line 12:\n  - initialise = True\n  + initialize = True",
 ]
 
 

--- a/tests/americanise_hook/test_system_americanise.py
+++ b/tests/americanise_hook/test_system_americanise.py
@@ -17,7 +17,7 @@ ARMOUR = True
 
 CoLoUr = False
 
-x = deInitIalise()
+initialise = True
 """
 
 us_file_content = """def initialize():
@@ -31,7 +31,7 @@ ARMOR = True
 
 CoLoR = False
 
-x = deInitIalize()
+initialize = True
 """
 
 

--- a/tests/examples/invalid_rst_python.py
+++ b/tests/examples/invalid_rst_python.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 """
 Module docstring.
@@ -17,7 +17,6 @@ def main():
     Function docstring.
     ================
     """
-    pass
 
 
 class foo:
@@ -31,7 +30,6 @@ class foo:
         Method docstring.
         ============
         """
-        pass
 
     class NestedClass:
         """
@@ -39,14 +37,12 @@ class foo:
         ==============
         """
 
-        pass
 
         def nested_method():
             """
             Nested Method docstring.
             =================
             """
-            pass
 
 
 expected_stdout: str = """- error in module docstring: Title underline too short.

--- a/tests/examples/no_docstrings.py
+++ b/tests/examples/no_docstrings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 CONST = 3
 
@@ -12,7 +12,6 @@ class foo:
         pass
 
     class NestedClass:
-        pass
 
         def nested_method():
             pass

--- a/tests/examples/valid_rst_python.py
+++ b/tests/examples/valid_rst_python.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery
 
 """Module docstring."""
 
@@ -8,7 +8,6 @@ CONST = 3
 
 def main():
     """Function docstring."""
-    pass
 
 
 class foo:
@@ -16,13 +15,10 @@ class foo:
 
     def method():
         """Method docstring"""
-        pass
 
     class NestedClass:
         """Nested CLass docstring."""
 
-        pass
 
         def nested_method():
             """Nested method docstring."""
-            pass

--- a/tests/sort_file_contents_hook/__init__.py
+++ b/tests/sort_file_contents_hook/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Benjamin Mummery
+# Copyright (c) 2023-2026 Benjamin Mummery

--- a/tests/sort_file_contents_hook/test_integration_sort_file_contents.py
+++ b/tests/sort_file_contents_hook/test_integration_sort_file_contents.py
@@ -288,9 +288,8 @@ class TestFailureStates:
         )
 
         # WHEN
-        with cwd(git_repo.workspace):
-            with pytest.raises(FileNotFoundError) as e:
-                sort_file_contents.main()
+        with cwd(git_repo.workspace), pytest.raises(FileNotFoundError) as e:
+            sort_file_contents.main()
 
         # THEN
         assert_matching(

--- a/tests/sync_type_hints_hook/__init__.py
+++ b/tests/sync_type_hints_hook/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025-2026 Benjamin Mummery

--- a/tests/sync_type_hints_hook/test_integration_sync_type_hints.py
+++ b/tests/sync_type_hints_hook/test_integration_sync_type_hints.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2025-2026 Benjamin Mummery
+import pytest
+
+from pytest_git import GitRepo
+from pytest_mock import MockerFixture
+
+from conftest import add_changed_files, assert_matching
+from src.sync_type_hints_hook import sync_type_hints
+
+google_input = '''def greet(name, count):
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+        count (int): How many times.
+
+    Returns:
+        bool: Whether greeting succeeded.
+    """
+    return True
+'''
+
+google_output = '''def greet(name: str, count: int) -> bool:
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+        count (int): How many times.
+
+    Returns:
+        bool: Whether greeting succeeded.
+    """
+    return True
+'''
+
+
+@pytest.fixture()
+def mock_colour(mocker):
+    mocker.patch(
+        "src.sync_type_hints_hook.sync_type_hints.print_diff.REMOVED_COLOUR",
+        "",
+    )
+    mocker.patch(
+        "src.sync_type_hints_hook.sync_type_hints.print_diff.ADDED_COLOUR",
+        "",
+    )
+    mocker.patch(
+        "src.sync_type_hints_hook.sync_type_hints.print_diff.END_COLOUR",
+        "",
+    )
+
+
+class TestAddMissingAnnotations:
+    @staticmethod
+    def test_google_docstring(
+        capsys: pytest.CaptureFixture,
+        mocker: MockerFixture,
+        git_repo: GitRepo,
+        cwd,
+        mock_colour,
+    ):
+        add_changed_files("hello.py", google_input, git_repo, mocker)
+
+        with cwd(git_repo.workspace):
+            assert sync_type_hints.main() == 1
+
+        with open(git_repo.workspace / "hello.py") as handle:
+            output_content = handle.read()
+
+        assert_matching(
+            "output content",
+            "expected content",
+            output_content,
+            google_output,
+        )
+        captured = capsys.readouterr()
+        assert "hello.py" in captured.out
+
+
+class TestTypeClash:
+    @staticmethod
+    def test_raises_on_clash(
+        capsys: pytest.CaptureFixture,
+        mocker: MockerFixture,
+        git_repo: GitRepo,
+        cwd,
+    ):
+        source = '''def greet(name: int):
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+    """
+    return True
+'''
+        add_changed_files("hello.py", source, git_repo, mocker)
+
+        with cwd(git_repo.workspace):
+            assert sync_type_hints.main() == 1
+
+        with open(git_repo.workspace / "hello.py") as handle:
+            assert handle.read() == source
+
+        captured = capsys.readouterr()
+        assert "type clash" in captured.err
+
+
+class TestPreferSignature:
+    @staticmethod
+    def test_updates_docstring(
+        capsys: pytest.CaptureFixture,
+        mocker: MockerFixture,
+        git_repo: GitRepo,
+        cwd,
+    ):
+        source = '''def greet(name: int) -> bool:
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+
+    Returns:
+        str: A message.
+    """
+    return True
+'''
+        expected = '''def greet(name: int) -> bool:
+    """Say hello.
+
+    Args:
+        name (int): Who to greet.
+
+    Returns:
+        bool: A message.
+    """
+    return True
+'''
+        add_changed_files("hello.py", source, git_repo, mocker)
+        mocker.patch(
+            "sys.argv",
+            ["stub_name", "--on-clash", "prefer-signature", "hello.py"],
+        )
+
+        with cwd(git_repo.workspace):
+            assert sync_type_hints.main() == 1
+
+        with open(git_repo.workspace / "hello.py") as handle:
+            assert_matching("output", "expected", handle.read(), expected)
+
+
+class TestRemoveDocstringTypes:
+    @staticmethod
+    def test_removes_google_types(
+        mocker: MockerFixture,
+        git_repo: GitRepo,
+        cwd,
+    ):
+        source = '''def greet(name: str) -> bool:
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+
+    Returns:
+        bool: Whether greeting succeeded.
+    """
+    return True
+'''
+        expected = '''def greet(name: str) -> bool:
+    """Say hello.
+
+    Args:
+        name: Who to greet.
+
+    Returns:
+        Whether greeting succeeded.
+    """
+    return True
+'''
+        add_changed_files("hello.py", source, git_repo, mocker)
+        mocker.patch(
+            "sys.argv",
+            ["stub_name", "--remove-docstring-types", "hello.py"],
+        )
+
+        with cwd(git_repo.workspace):
+            assert sync_type_hints.main() == 1
+
+        with open(git_repo.workspace / "hello.py") as handle:
+            assert_matching("output", "expected", handle.read(), expected)

--- a/tests/sync_type_hints_hook/test_system_sync_type_hints.py
+++ b/tests/sync_type_hints_hook/test_system_sync_type_hints.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025-2026 Benjamin Mummery
+import os
+import subprocess
+
+from pytest_git import GitRepo
+
+COMMAND = ["pre-commit", "try-repo", f"{os.getcwd()}", "sync-type-hints"]
+
+google_input = '''def greet(name, count):
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+        count (int): How many times.
+
+    Returns:
+        bool: Whether greeting succeeded.
+    """
+    return True
+'''
+
+google_output = '''def greet(name: str, count: int) -> bool:
+    """Say hello.
+
+    Args:
+        name (str): Who to greet.
+        count (int): How many times.
+
+    Returns:
+        bool: Whether greeting succeeded.
+    """
+    return True
+'''
+
+
+class TestNoChanges:
+    @staticmethod
+    def test_no_files_changed(git_repo: GitRepo, cwd):
+        with cwd(git_repo.workspace):
+            process = subprocess.run(
+                COMMAND,
+                capture_output=True,
+                text=True,
+            )
+
+        assert process.returncode == 0, process.stdout + process.stderr
+        assert "Sync type hints with docstrings" in process.stdout
+        assert "Passed" in process.stdout
+
+
+class TestChanges:
+    @staticmethod
+    def test_adds_missing_annotations(git_repo: GitRepo, cwd):
+        file = "file.py"
+        f = git_repo.workspace / file
+        f.write_text(google_input)
+        git_repo.run(f"git add {file}")
+
+        with cwd(git_repo.workspace):
+            process = subprocess.run(
+                COMMAND,
+                capture_output=True,
+                text=True,
+            )
+
+        assert process.returncode == 1, process.stdout + process.stderr
+        with open(f) as handle:
+            assert handle.read() == google_output
+        assert "Failed" in process.stdout

--- a/tests/update_copyright_hook/test_integration_update_copyright.py
+++ b/tests/update_copyright_hook/test_integration_update_copyright.py
@@ -222,7 +222,7 @@ class TestChanges:
         expected_content = f"{new_copyright_string}\n\n<file content sentinel>"
         expected_stdout = (
             f"Fixing file `{file}`:\n"
-            f"  - {language.comment_format.format(content=input_copyright_string)}\n"  # noqa: E501
+            f"  - {language.comment_format.format(content=input_copyright_string)}\n"
             f"  + {new_copyright_string}\n"
         )
 
@@ -287,7 +287,7 @@ class TestChanges:
         expected_content = f"{new_copyright_string}\n\n<file content sentinel>"
         expected_stdout = (
             f"Fixing file `{file}`:\n"
-            f"  - {language.comment_format.format(content=input_copyright_string)}\n"  # noqa: E501
+            f"  - {language.comment_format.format(content=input_copyright_string)}\n"
             f"  + {new_copyright_string}\n"
         )
 
@@ -465,9 +465,8 @@ class TestFailureStates:
         )
 
         # WHEN
-        with cwd(git_repo.workspace):
-            with pytest.raises(ValueError) as e:
-                update_copyright.main()
+        with cwd(git_repo.workspace), pytest.raises(ValueError) as e:
+            update_copyright.main()
 
         # THEN
         assert_matching(
@@ -491,9 +490,8 @@ class TestFailureStates:
         add_changed_files("hello.fake", "", git_repo, mocker)
 
         # WHEN
-        with cwd(git_repo.workspace):
-            with pytest.raises(NotImplementedError) as e:
-                update_copyright.main()
+        with cwd(git_repo.workspace), pytest.raises(NotImplementedError) as e:
+            update_copyright.main()
 
         # THEN
         assert e.exconly().startswith(

--- a/uv.lock
+++ b/uv.lock
@@ -653,58 +653,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "5.0.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "mccabe", marker = "python_full_version < '3.8.1'" },
-    { name = "pycodestyle", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
-    { name = "pyflakes", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/00/9808c62b2d529cefc69ce4e4a1ea42c0f855effa55817b7327ec5b75e60a/flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db", size = 145862, upload-time = "2022-08-03T23:21:27.108Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/a0/b881b63a17a59d9d07f5c0cc91a29182c8e8a9aa2bde5b3b2b16519c02f4/flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248", size = 61897, upload-time = "2022-08-03T23:21:25.027Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.1.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "mccabe", marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
-    { name = "pycodestyle", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
-    { name = "pyflakes", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/16/3f2a0bb700ad65ac9663262905a025917c020a3f92f014d2ba8964b4602c/flake8-7.1.2.tar.gz", hash = "sha256:c586ffd0b41540951ae41af572e6790dbd49fc12b3aa2541685d253d9bd504bd", size = 48119, upload-time = "2025-02-16T18:45:44.296Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/f8/08d37b2cd89da306e3520bd27f8a85692122b42b56c0c2c3784ff09c022f/flake8-7.1.2-py2.py3-none-any.whl", hash = "sha256:1cbc62e65536f65e6d754dfe6f1bada7f5cf392d6f5db3c2b85892466c3e7c1a", size = 57745, upload-time = "2025-02-16T18:45:42.351Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
-dependencies = [
-    { name = "mccabe", marker = "python_full_version >= '3.9'" },
-    { name = "pycodestyle", version = "2.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pyflakes", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
 name = "freezegun"
 version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1054,15 +1002,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1238,6 +1177,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit-hooks"
+version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
@@ -1253,9 +1193,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "flake8", version = "5.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
-    { name = "flake8", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
-    { name = "flake8", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "freezegun" },
     { name = "pre-commit", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
@@ -1269,6 +1206,7 @@ dev = [
     { name = "pytest-mock", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-mock", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "python-semantic-release" },
+    { name = "ruff" },
 ]
 test = [
     { name = "freezegun" },
@@ -1297,7 +1235,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "flake8", specifier = ">=5.0.4" },
     { name = "freezegun", specifier = ">=1.5.5" },
     { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=8.3.5" },
@@ -1305,6 +1242,7 @@ dev = [
     { name = "pytest-git", specifier = ">=1.8.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "python-semantic-release", specifier = ">=10.5.3" },
+    { name = "ruff", specifier = ">=0.15.0" },
 ]
 test = [
     { name = "freezegun", specifier = ">=1.5.5" },
@@ -1313,43 +1251,6 @@ test = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-git", specifier = ">=1.8.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/83/5bcaedba1f47200f0665ceb07bcb00e2be123192742ee0edfb66b600e5fd/pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785", size = 102127, upload-time = "2022-08-03T23:13:29.715Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/e4/fc77f1039c34b3612c4867b69cbb2b8a4e569720b1f19b0637002ee03aff/pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b", size = 41493, upload-time = "2022-08-03T23:13:27.416Z" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.12.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/aa/210b2c9aedd8c1cbeea31a50e42050ad56187754b34eb214c46709445801/pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521", size = 39232, upload-time = "2024-08-04T20:26:54.576Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/d8/a211b3f85e99a0daa2ddec96c949cac6824bd305b040571b82a03dd62636/pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3", size = 31284, upload-time = "2024-08-04T20:26:53.173Z" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
 ]
 
 [[package]]
@@ -1636,43 +1537,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/92/f0cb5381f752e89a598dd2850941e7f570ac3cb8ea4a344854de486db152/pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3", size = 66388, upload-time = "2022-07-30T17:29:05.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/13/63178f59f74e53acc2165aee4b002619a3cfa7eeaeac989a9eb41edf364e/pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2", size = 66116, upload-time = "2022-07-30T17:29:04.179Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/f9/669d8c9c86613c9d568757c7f5824bd3197d7b1c6c27553bc5618a27cce2/pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f", size = 63788, upload-time = "2024-01-05T00:28:47.703Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/d7/f1b7db88d8e4417c5d47adad627a93547f44bdc9028372dbd2313f34a855/pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a", size = 62725, upload-time = "2024-01-05T00:28:45.903Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -2082,6 +1946,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,20 +1,15 @@
 version = 1
 revision = 3
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
+    "python_full_version < '3.10'",
 ]
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -34,9 +29,7 @@ name = "cfgv"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
 wheels = [
@@ -141,21 +134,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4e/3926a1c11f0433791985727965263f788af00db3482d89a7545ca5ecc921/charset_normalizer-3.4.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84", size = 198599, upload-time = "2025-10-14T04:41:53.213Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/7c/b92d1d1dcffc34592e71ea19c882b6709e43d20fa498042dea8b815638d7/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3", size = 143090, upload-time = "2025-10-14T04:41:54.385Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ce/61a28d3bb77281eb24107b937a497f3c43089326d27832a63dcedaab0478/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac", size = 139490, upload-time = "2025-10-14T04:41:55.551Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/bd/c9e59a91b2061c6f8bb98a150670cb16d4cd7c4ba7d11ad0cdf789155f41/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af", size = 155334, upload-time = "2025-10-14T04:41:56.724Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/37/f17ae176a80f22ff823456af91ba3bc59df308154ff53aef0d39eb3d3419/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2", size = 152823, upload-time = "2025-10-14T04:41:58.236Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/fa/cf5bb2409a385f78750e78c8d2e24780964976acdaaed65dbd6083ae5b40/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d", size = 147618, upload-time = "2025-10-14T04:41:59.409Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/63/579784a65bc7de2d4518d40bb8f1870900163e86f17f21fd1384318c459d/charset_normalizer-3.4.4-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3", size = 145516, upload-time = "2025-10-14T04:42:00.579Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/a9/94ec6266cd394e8f93a4d69cca651d61bf6ac58d2a0422163b30c698f2c7/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63", size = 145266, upload-time = "2025-10-14T04:42:01.684Z" },
-    { url = "https://files.pythonhosted.org/packages/09/14/d6626eb97764b58c2779fa7928fa7d1a49adb8ce687c2dbba4db003c1939/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7", size = 139559, upload-time = "2025-10-14T04:42:02.902Z" },
-    { url = "https://files.pythonhosted.org/packages/09/01/ddbe6b01313ba191dbb0a43c7563bc770f2448c18127f9ea4b119c44dff0/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4", size = 156653, upload-time = "2025-10-14T04:42:04.005Z" },
-    { url = "https://files.pythonhosted.org/packages/95/c8/d05543378bea89296e9af4510b44c704626e191da447235c8fdedfc5b7b2/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf", size = 145644, upload-time = "2025-10-14T04:42:05.211Z" },
-    { url = "https://files.pythonhosted.org/packages/72/01/2866c4377998ef8a1f6802f6431e774a4c8ebe75b0a6e569ceec55c9cbfb/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074", size = 153964, upload-time = "2025-10-14T04:42:06.341Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/66/66c72468a737b4cbd7851ba2c522fe35c600575fbeac944460b4fd4a06fe/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a", size = 148777, upload-time = "2025-10-14T04:42:07.535Z" },
-    { url = "https://files.pythonhosted.org/packages/50/94/d0d56677fdddbffa8ca00ec411f67bb8c947f9876374ddc9d160d4f2c4b3/charset_normalizer-3.4.4-cp38-cp38-win32.whl", hash = "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa", size = 98687, upload-time = "2025-10-14T04:42:08.678Z" },
-    { url = "https://files.pythonhosted.org/packages/00/64/c3bc303d1b586480b1c8e6e1e2191a6d6dd40255244e5cf16763dcec52e6/charset_normalizer-3.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576", size = 106115, upload-time = "2025-10-14T04:42:09.793Z" },
     { url = "https://files.pythonhosted.org/packages/46/7c/0c4760bccf082737ca7ab84a4c2034fcc06b1f21cf3032ea98bd6feb1725/charset_normalizer-3.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9", size = 209609, upload-time = "2025-10-14T04:42:10.922Z" },
     { url = "https://files.pythonhosted.org/packages/bb/a4/69719daef2f3d7f1819de60c9a6be981b8eeead7542d5ec4440f3c80e111/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d", size = 149029, upload-time = "2025-10-14T04:42:12.38Z" },
     { url = "https://files.pythonhosted.org/packages/e6/21/8d4e1d6c1e6070d3672908b8e4533a71b5b53e71d16828cc24d0efec564c/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608", size = 144580, upload-time = "2025-10-14T04:42:13.549Z" },
@@ -210,98 +188,10 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/08/7e37f82e4d1aead42a7443ff06a1e406aabf7302c4f00a546e4b320b994c/coverage-7.6.1.tar.gz", hash = "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d", size = 798791, upload-time = "2024-08-04T19:45:30.9Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/61/eb7ce5ed62bacf21beca4937a90fe32545c91a3c8a42a30c6616d48fc70d/coverage-7.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16", size = 206690, upload-time = "2024-08-04T19:43:07.695Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/73/041928e434442bd3afde5584bdc3f932fb4562b1597629f537387cec6f3d/coverage-7.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36", size = 207127, upload-time = "2024-08-04T19:43:10.15Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/c8/6ca52b5147828e45ad0242388477fdb90df2c6cbb9a441701a12b3c71bc8/coverage-7.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02", size = 235654, upload-time = "2024-08-04T19:43:12.405Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/da/9ac2b62557f4340270942011d6efeab9833648380109e897d48ab7c1035d/coverage-7.6.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc", size = 233598, upload-time = "2024-08-04T19:43:14.078Z" },
-    { url = "https://files.pythonhosted.org/packages/53/23/9e2c114d0178abc42b6d8d5281f651a8e6519abfa0ef460a00a91f80879d/coverage-7.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23", size = 234732, upload-time = "2024-08-04T19:43:16.632Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/7e/a0230756fb133343a52716e8b855045f13342b70e48e8ad41d8a0d60ab98/coverage-7.6.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a1ac0ae2b8bd743b88ed0502544847c3053d7171a3cff9228af618a068ed9c34", size = 233816, upload-time = "2024-08-04T19:43:19.049Z" },
-    { url = "https://files.pythonhosted.org/packages/28/7c/3753c8b40d232b1e5eeaed798c875537cf3cb183fb5041017c1fdb7ec14e/coverage-7.6.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e6a08c0be454c3b3beb105c0596ebdc2371fab6bb90c0c0297f4e58fd7e1012c", size = 232325, upload-time = "2024-08-04T19:43:21.246Z" },
-    { url = "https://files.pythonhosted.org/packages/57/e3/818a2b2af5b7573b4b82cf3e9f137ab158c90ea750a8f053716a32f20f06/coverage-7.6.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f5796e664fe802da4f57a168c85359a8fbf3eab5e55cd4e4569fbacecc903959", size = 233418, upload-time = "2024-08-04T19:43:22.945Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/fb/4532b0b0cefb3f06d201648715e03b0feb822907edab3935112b61b885e2/coverage-7.6.1-cp310-cp310-win32.whl", hash = "sha256:7bb65125fcbef8d989fa1dd0e8a060999497629ca5b0efbca209588a73356232", size = 209343, upload-time = "2024-08-04T19:43:25.121Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/25/af337cc7421eca1c187cc9c315f0a755d48e755d2853715bfe8c418a45fa/coverage-7.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:3115a95daa9bdba70aea750db7b96b37259a81a709223c8448fa97727d546fe0", size = 210136, upload-time = "2024-08-04T19:43:26.851Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/5f/67af7d60d7e8ce61a4e2ddcd1bd5fb787180c8d0ae0fbd073f903b3dd95d/coverage-7.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93", size = 206796, upload-time = "2024-08-04T19:43:29.115Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/0e/e52332389e057daa2e03be1fbfef25bb4d626b37d12ed42ae6281d0a274c/coverage-7.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3", size = 207244, upload-time = "2024-08-04T19:43:31.285Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/cd/766b45fb6e090f20f8927d9c7cb34237d41c73a939358bc881883fd3a40d/coverage-7.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff", size = 239279, upload-time = "2024-08-04T19:43:33.581Z" },
-    { url = "https://files.pythonhosted.org/packages/70/6c/a9ccd6fe50ddaf13442a1e2dd519ca805cbe0f1fcd377fba6d8339b98ccb/coverage-7.6.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bc572be474cafb617672c43fe989d6e48d3c83af02ce8de73fff1c6bb3c198d", size = 236859, upload-time = "2024-08-04T19:43:35.301Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6f/8351b465febb4dbc1ca9929505202db909c5a635c6fdf33e089bbc3d7d85/coverage-7.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6", size = 238549, upload-time = "2024-08-04T19:43:37.578Z" },
-    { url = "https://files.pythonhosted.org/packages/68/3c/289b81fa18ad72138e6d78c4c11a82b5378a312c0e467e2f6b495c260907/coverage-7.6.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1f4aa8219db826ce6be7099d559f8ec311549bfc4046f7f9fe9b5cea5c581c56", size = 237477, upload-time = "2024-08-04T19:43:39.92Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1c/aa1efa6459d822bd72c4abc0b9418cf268de3f60eeccd65dc4988553bd8d/coverage-7.6.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234", size = 236134, upload-time = "2024-08-04T19:43:41.453Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c8/521c698f2d2796565fe9c789c2ee1ccdae610b3aa20b9b2ef980cc253640/coverage-7.6.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b48f312cca9621272ae49008c7f613337c53fadca647d6384cc129d2996d1133", size = 236910, upload-time = "2024-08-04T19:43:43.037Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/30/033e663399ff17dca90d793ee8a2ea2890e7fdf085da58d82468b4220bf7/coverage-7.6.1-cp311-cp311-win32.whl", hash = "sha256:1125ca0e5fd475cbbba3bb67ae20bd2c23a98fac4e32412883f9bcbaa81c314c", size = 209348, upload-time = "2024-08-04T19:43:44.787Z" },
-    { url = "https://files.pythonhosted.org/packages/20/05/0d1ccbb52727ccdadaa3ff37e4d2dc1cd4d47f0c3df9eb58d9ec8508ca88/coverage-7.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:8ae539519c4c040c5ffd0632784e21b2f03fc1340752af711f33e5be83a9d6c6", size = 210230, upload-time = "2024-08-04T19:43:46.707Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/d4/300fc921dff243cd518c7db3a4c614b7e4b2431b0d1145c1e274fd99bd70/coverage-7.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778", size = 206983, upload-time = "2024-08-04T19:43:49.082Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ab/6bf00de5327ecb8db205f9ae596885417a31535eeda6e7b99463108782e1/coverage-7.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391", size = 207221, upload-time = "2024-08-04T19:43:52.15Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8f/2ead05e735022d1a7f3a0a683ac7f737de14850395a826192f0288703472/coverage-7.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8", size = 240342, upload-time = "2024-08-04T19:43:53.746Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ef/94043e478201ffa85b8ae2d2c79b4081e5a1b73438aafafccf3e9bafb6b5/coverage-7.6.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d", size = 237371, upload-time = "2024-08-04T19:43:55.993Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0f/c890339dd605f3ebc269543247bdd43b703cce6825b5ed42ff5f2d6122c7/coverage-7.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca", size = 239455, upload-time = "2024-08-04T19:43:57.618Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/04/7fd7b39ec7372a04efb0f70c70e35857a99b6a9188b5205efb4c77d6a57a/coverage-7.6.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877abb17e6339d96bf08e7a622d05095e72b71f8afd8a9fefc82cf30ed944163", size = 238924, upload-time = "2024-08-04T19:44:00.012Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/bf/73ce346a9d32a09cf369f14d2a06651329c984e106f5992c89579d25b27e/coverage-7.6.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e0cadcf6733c09154b461f1ca72d5416635e5e4ec4e536192180d34ec160f8a", size = 237252, upload-time = "2024-08-04T19:44:01.713Z" },
-    { url = "https://files.pythonhosted.org/packages/86/74/1dc7a20969725e917b1e07fe71a955eb34bc606b938316bcc799f228374b/coverage-7.6.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3c02d12f837d9683e5ab2f3d9844dc57655b92c74e286c262e0fc54213c216d", size = 238897, upload-time = "2024-08-04T19:44:03.898Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e9/d9cc3deceb361c491b81005c668578b0dfa51eed02cd081620e9a62f24ec/coverage-7.6.1-cp312-cp312-win32.whl", hash = "sha256:e05882b70b87a18d937ca6768ff33cc3f72847cbc4de4491c8e73880766718e5", size = 209606, upload-time = "2024-08-04T19:44:05.532Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c8/5a2e41922ea6740f77d555c4d47544acd7dc3f251fe14199c09c0f5958d3/coverage-7.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:b5d7b556859dd85f3a541db6a4e0167b86e7273e1cdc973e5b175166bb634fdb", size = 210373, upload-time = "2024-08-04T19:44:07.079Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/f9/9aa4dfb751cb01c949c990d136a0f92027fbcc5781c6e921df1cb1563f20/coverage-7.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a4acd025ecc06185ba2b801f2de85546e0b8ac787cf9d3b06e7e2a69f925b106", size = 207007, upload-time = "2024-08-04T19:44:09.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/67/e1413d5a8591622a46dd04ff80873b04c849268831ed5c304c16433e7e30/coverage-7.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a6d3adcf24b624a7b778533480e32434a39ad8fa30c315208f6d3e5542aeb6e9", size = 207269, upload-time = "2024-08-04T19:44:11.045Z" },
-    { url = "https://files.pythonhosted.org/packages/14/5b/9dec847b305e44a5634d0fb8498d135ab1d88330482b74065fcec0622224/coverage-7.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0c212c49b6c10e6951362f7c6df3329f04c2b1c28499563d4035d964ab8e08c", size = 239886, upload-time = "2024-08-04T19:44:12.83Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/b7/35760a67c168e29f454928f51f970342d23cf75a2bb0323e0f07334c85f3/coverage-7.6.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e81d7a3e58882450ec4186ca59a3f20a5d4440f25b1cff6f0902ad890e6748a", size = 237037, upload-time = "2024-08-04T19:44:15.393Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/95/d2fd31f1d638df806cae59d7daea5abf2b15b5234016a5ebb502c2f3f7ee/coverage-7.6.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78b260de9790fd81e69401c2dc8b17da47c8038176a79092a89cb2b7d945d060", size = 239038, upload-time = "2024-08-04T19:44:17.466Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/bd/110689ff5752b67924efd5e2aedf5190cbbe245fc81b8dec1abaffba619d/coverage-7.6.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a78d169acd38300060b28d600344a803628c3fd585c912cacc9ea8790fe96862", size = 238690, upload-time = "2024-08-04T19:44:19.336Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/a8/08d7b38e6ff8df52331c83130d0ab92d9c9a8b5462f9e99c9f051a4ae206/coverage-7.6.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c09f4ce52cb99dd7505cd0fc8e0e37c77b87f46bc9c1eb03fe3bc9991085388", size = 236765, upload-time = "2024-08-04T19:44:20.994Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/6a/9cf96839d3147d55ae713eb2d877f4d777e7dc5ba2bce227167d0118dfe8/coverage-7.6.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6878ef48d4227aace338d88c48738a4258213cd7b74fd9a3d4d7582bb1d8a155", size = 238611, upload-time = "2024-08-04T19:44:22.616Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e4/7ff20d6a0b59eeaab40b3140a71e38cf52547ba21dbcf1d79c5a32bba61b/coverage-7.6.1-cp313-cp313-win32.whl", hash = "sha256:44df346d5215a8c0e360307d46ffaabe0f5d3502c8a1cefd700b34baf31d411a", size = 209671, upload-time = "2024-08-04T19:44:24.418Z" },
-    { url = "https://files.pythonhosted.org/packages/35/59/1812f08a85b57c9fdb6d0b383d779e47b6f643bc278ed682859512517e83/coverage-7.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:8284cf8c0dd272a247bc154eb6c95548722dce90d098c17a883ed36e67cdb129", size = 210368, upload-time = "2024-08-04T19:44:26.276Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/15/08913be1c59d7562a3e39fce20661a98c0a3f59d5754312899acc6cb8a2d/coverage-7.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d3296782ca4eab572a1a4eca686d8bfb00226300dcefdf43faa25b5242ab8a3e", size = 207758, upload-time = "2024-08-04T19:44:29.028Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ae/b5d58dff26cade02ada6ca612a76447acd69dccdbb3a478e9e088eb3d4b9/coverage-7.6.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:502753043567491d3ff6d08629270127e0c31d4184c4c8d98f92c26f65019962", size = 208035, upload-time = "2024-08-04T19:44:30.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d7/62095e355ec0613b08dfb19206ce3033a0eedb6f4a67af5ed267a8800642/coverage-7.6.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a89ecca80709d4076b95f89f308544ec8f7b4727e8a547913a35f16717856cb", size = 250839, upload-time = "2024-08-04T19:44:32.412Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/1e/c2967cb7991b112ba3766df0d9c21de46b476d103e32bb401b1b2adf3380/coverage-7.6.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a318d68e92e80af8b00fa99609796fdbcdfef3629c77c6283566c6f02c6d6704", size = 246569, upload-time = "2024-08-04T19:44:34.547Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/61/a7a6a55dd266007ed3b1df7a3386a0d760d014542d72f7c2c6938483b7bd/coverage-7.6.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13b0a73a0896988f053e4fbb7de6d93388e6dd292b0d87ee51d106f2c11b465b", size = 248927, upload-time = "2024-08-04T19:44:36.313Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/fa/13a6f56d72b429f56ef612eb3bc5ce1b75b7ee12864b3bd12526ab794847/coverage-7.6.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4421712dbfc5562150f7554f13dde997a2e932a6b5f352edcce948a815efee6f", size = 248401, upload-time = "2024-08-04T19:44:38.155Z" },
-    { url = "https://files.pythonhosted.org/packages/75/06/0429c652aa0fb761fc60e8c6b291338c9173c6aa0f4e40e1902345b42830/coverage-7.6.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:166811d20dfea725e2e4baa71fffd6c968a958577848d2131f39b60043400223", size = 246301, upload-time = "2024-08-04T19:44:39.883Z" },
-    { url = "https://files.pythonhosted.org/packages/52/76/1766bb8b803a88f93c3a2d07e30ffa359467810e5cbc68e375ebe6906efb/coverage-7.6.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:225667980479a17db1048cb2bf8bfb39b8e5be8f164b8f6628b64f78a72cf9d3", size = 247598, upload-time = "2024-08-04T19:44:41.59Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8b/f54f8db2ae17188be9566e8166ac6df105c1c611e25da755738025708d54/coverage-7.6.1-cp313-cp313t-win32.whl", hash = "sha256:170d444ab405852903b7d04ea9ae9b98f98ab6d7e63e1115e82620807519797f", size = 210307, upload-time = "2024-08-04T19:44:43.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/b0/e0dca6da9170aefc07515cce067b97178cefafb512d00a87a1c717d2efd5/coverage-7.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b9f222de8cded79c49bf184bdbc06630d4c58eec9459b939b4a690c82ed05657", size = 211453, upload-time = "2024-08-04T19:44:45.677Z" },
-    { url = "https://files.pythonhosted.org/packages/81/d0/d9e3d554e38beea5a2e22178ddb16587dbcbe9a1ef3211f55733924bf7fa/coverage-7.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6db04803b6c7291985a761004e9060b2bca08da6d04f26a7f2294b8623a0c1a0", size = 206674, upload-time = "2024-08-04T19:44:47.694Z" },
-    { url = "https://files.pythonhosted.org/packages/38/ea/cab2dc248d9f45b2b7f9f1f596a4d75a435cb364437c61b51d2eb33ceb0e/coverage-7.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f1adfc8ac319e1a348af294106bc6a8458a0f1633cc62a1446aebc30c5fa186a", size = 207101, upload-time = "2024-08-04T19:44:49.32Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6f/f82f9a500c7c5722368978a5390c418d2a4d083ef955309a8748ecaa8920/coverage-7.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a95324a9de9650a729239daea117df21f4b9868ce32e63f8b650ebe6cef5595b", size = 236554, upload-time = "2024-08-04T19:44:51.631Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/94/d3055aa33d4e7e733d8fa309d9adf147b4b06a82c1346366fc15a2b1d5fa/coverage-7.6.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b43c03669dc4618ec25270b06ecd3ee4fa94c7f9b3c14bae6571ca00ef98b0d3", size = 234440, upload-time = "2024-08-04T19:44:53.464Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/6e/885bcd787d9dd674de4a7d8ec83faf729534c63d05d51d45d4fa168f7102/coverage-7.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8929543a7192c13d177b770008bc4e8119f2e1f881d563fc6b6305d2d0ebe9de", size = 235889, upload-time = "2024-08-04T19:44:55.165Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/63/df50120a7744492710854860783d6819ff23e482dee15462c9a833cc428a/coverage-7.6.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:a09ece4a69cf399510c8ab25e0950d9cf2b42f7b3cb0374f95d2e2ff594478a6", size = 235142, upload-time = "2024-08-04T19:44:57.269Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5d/9d0acfcded2b3e9ce1c7923ca52ccc00c78a74e112fc2aee661125b7843b/coverage-7.6.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:9054a0754de38d9dbd01a46621636689124d666bad1936d76c0341f7d71bf569", size = 233805, upload-time = "2024-08-04T19:44:59.033Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/56/50abf070cb3cd9b1dd32f2c88f083aab561ecbffbcd783275cb51c17f11d/coverage-7.6.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0dbde0f4aa9a16fa4d754356a8f2e36296ff4d83994b2c9d8398aa32f222f989", size = 234655, upload-time = "2024-08-04T19:45:01.398Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ee/b4c246048b8485f85a2426ef4abab88e48c6e80c74e964bea5cd4cd4b115/coverage-7.6.1-cp38-cp38-win32.whl", hash = "sha256:da511e6ad4f7323ee5702e6633085fb76c2f893aaf8ce4c51a0ba4fc07580ea7", size = 209296, upload-time = "2024-08-04T19:45:03.819Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/1c/96cf86b70b69ea2b12924cdf7cabb8ad10e6130eab8d767a1099fbd2a44f/coverage-7.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:3f1156e3e8f2872197af3840d8ad307a9dd18e615dc64d9ee41696f287c57ad8", size = 210137, upload-time = "2024-08-04T19:45:06.25Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d3/d54c5aa83268779d54c86deb39c1c4566e5d45c155369ca152765f8db413/coverage-7.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255", size = 206688, upload-time = "2024-08-04T19:45:08.358Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/fe/137d5dca72e4a258b1bc17bb04f2e0196898fe495843402ce826a7419fe3/coverage-7.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8", size = 207120, upload-time = "2024-08-04T19:45:11.526Z" },
-    { url = "https://files.pythonhosted.org/packages/78/5b/a0a796983f3201ff5485323b225d7c8b74ce30c11f456017e23d8e8d1945/coverage-7.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2", size = 235249, upload-time = "2024-08-04T19:45:13.202Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/e1/76089d6a5ef9d68f018f65411fcdaaeb0141b504587b901d74e8587606ad/coverage-7.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e0b2df163b8ed01d515807af24f63de04bebcecbd6c3bfeff88385789fdf75a", size = 233237, upload-time = "2024-08-04T19:45:14.961Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/eef79b779a540326fee9520e5542a8b428cc3bfa8b7c8f1022c1ee4fc66c/coverage-7.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc", size = 234311, upload-time = "2024-08-04T19:45:16.924Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e1/656d65fb126c29a494ef964005702b012f3498db1a30dd562958e85a4049/coverage-7.6.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:702855feff378050ae4f741045e19a32d57d19f3e0676d589df0575008ea5004", size = 233453, upload-time = "2024-08-04T19:45:18.672Z" },
-    { url = "https://files.pythonhosted.org/packages/68/6a/45f108f137941a4a1238c85f28fd9d048cc46b5466d6b8dda3aba1bb9d4f/coverage-7.6.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2bdb062ea438f22d99cba0d7829c2ef0af1d768d1e4a4f528087224c90b132cb", size = 231958, upload-time = "2024-08-04T19:45:20.63Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e7/47b809099168b8b8c72ae311efc3e88c8d8a1162b3ba4b8da3cfcdb85743/coverage-7.6.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9c56863d44bd1c4fe2abb8a4d6f5371d197f1ac0ebdee542f07f35895fc07f36", size = 232938, upload-time = "2024-08-04T19:45:23.062Z" },
-    { url = "https://files.pythonhosted.org/packages/52/80/052222ba7058071f905435bad0ba392cc12006380731c37afaf3fe749b88/coverage-7.6.1-cp39-cp39-win32.whl", hash = "sha256:6e2cd258d7d927d09493c8df1ce9174ad01b381d4729a9d8d4e38670ca24774c", size = 209352, upload-time = "2024-08-04T19:45:25.042Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d8/1b92e0b3adcf384e98770a00ca095da1b5f7b483e6563ae4eb5e935d24a1/coverage-7.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca", size = 210153, upload-time = "2024-08-04T19:45:27.079Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/2b/0354ed096bca64dc8e32a7cbcae28b34cb5ad0b1fe2125d6d99583313ac0/coverage-7.6.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df", size = 198926, upload-time = "2024-08-04T19:45:28.875Z" },
-]
-
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-]
-
-[[package]]
-name = "coverage"
 version = "7.10.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704, upload-time = "2025-09-21T20:03:56.815Z" }
 wheels = [
@@ -412,7 +302,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version == '3.9.*'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -541,8 +431,7 @@ name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt", version = "2.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "wrapt", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
@@ -560,25 +449,8 @@ wheels = [
 
 [[package]]
 name = "docutils"
-version = "0.20.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b", size = 2058365, upload-time = "2023-05-16T23:39:19.748Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6", size = 572666, upload-time = "2023-05-16T23:39:15.976Z" },
-]
-
-[[package]]
-name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
@@ -598,8 +470,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -617,23 +488,10 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.16.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/db/3ef5bb276dae18d6ec2124224403d1d67bccdbefc17af4cc8f553e341ab1/filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435", size = 18037, upload-time = "2024-09-17T19:02:01.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0", size = 16163, upload-time = "2024-09-17T19:02:00.268Z" },
-]
-
-[[package]]
-name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
 wheels = [
@@ -682,8 +540,7 @@ version = "3.1.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
 wheels = [
@@ -692,23 +549,10 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/bb/25024dbcc93516c492b75919e76f389bac754a3e4248682fba32b250c880/identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98", size = 99097, upload-time = "2024-09-14T23:50:32.513Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/0c/4ef72754c050979fdcc06c744715ae70ea37e734816bb6514f79df77a42f/identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0", size = 98972, upload-time = "2024-09-14T23:50:30.747Z" },
-]
-
-[[package]]
-name = "identify"
 version = "2.6.15"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
 wheels = [
@@ -738,30 +582,10 @@ wheels = [
 
 [[package]]
 name = "importlib-resources"
-version = "6.4.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "zipp", version = "3.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/be/f3e8c6081b684f176b761e6a2fef02a0be939740ed6f54109a2951d806f3/importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065", size = 43372, upload-time = "2024-09-09T17:03:14.677Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/6a/4604f9ae2fa62ef47b9de2fa5ad599589d28c9fd1d335f32759813dfa91e/importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717", size = 36115, upload-time = "2024-09-09T17:03:13.39Z" },
-]
-
-[[package]]
-name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "zipp", version = "3.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
@@ -773,9 +597,7 @@ name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
@@ -799,8 +621,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markupsafe", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -812,9 +633,7 @@ name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
+    "python_full_version < '3.10'",
 ]
 dependencies = [
     { name = "mdurl", marker = "python_full_version < '3.10'" },
@@ -841,74 +660,8 @@ wheels = [
 
 [[package]]
 name = "markupsafe"
-version = "2.1.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384, upload-time = "2024-02-02T16:31:22.863Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/54/ad5eb37bf9d51800010a74e4665425831a9db4e7c4e0fde4352e391e808e/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc", size = 18206, upload-time = "2024-02-02T16:30:04.105Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/4a/a4d49415e600bacae038c67f9fecc1d5433b9d3c71a4de6f33537b89654c/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5", size = 14079, upload-time = "2024-02-02T16:30:06.5Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46", size = 26620, upload-time = "2024-02-02T16:30:08.31Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f", size = 25818, upload-time = "2024-02-02T16:30:09.577Z" },
-    { url = "https://files.pythonhosted.org/packages/29/fe/a36ba8c7ca55621620b2d7c585313efd10729e63ef81e4e61f52330da781/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900", size = 25493, upload-time = "2024-02-02T16:30:11.488Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ae/9c60231cdfda003434e8bd27282b1f4e197ad5a710c14bee8bea8a9ca4f0/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff", size = 30630, upload-time = "2024-02-02T16:30:13.144Z" },
-    { url = "https://files.pythonhosted.org/packages/65/dc/1510be4d179869f5dafe071aecb3f1f41b45d37c02329dfba01ff59e5ac5/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad", size = 29745, upload-time = "2024-02-02T16:30:14.222Z" },
-    { url = "https://files.pythonhosted.org/packages/30/39/8d845dd7d0b0613d86e0ef89549bfb5f61ed781f59af45fc96496e897f3a/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd", size = 30021, upload-time = "2024-02-02T16:30:16.032Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5c/356a6f62e4f3c5fbf2602b4771376af22a3b16efa74eb8716fb4e328e01e/MarkupSafe-2.1.5-cp310-cp310-win32.whl", hash = "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4", size = 16659, upload-time = "2024-02-02T16:30:17.079Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/acbf292615c65f0604a0c6fc402ce6d8c991276e16c80c46a8f758fbd30c/MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5", size = 17213, upload-time = "2024-02-02T16:30:18.251Z" },
-    { url = "https://files.pythonhosted.org/packages/11/e7/291e55127bb2ae67c64d66cef01432b5933859dfb7d6949daa721b89d0b3/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f", size = 18219, upload-time = "2024-02-02T16:30:19.988Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2", size = 14098, upload-time = "2024-02-02T16:30:21.063Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/cf/35fe557e53709e93feb65575c93927942087e9b97213eabc3fe9d5b25a55/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced", size = 29014, upload-time = "2024-02-02T16:30:22.926Z" },
-    { url = "https://files.pythonhosted.org/packages/97/18/c30da5e7a0e7f4603abfc6780574131221d9148f323752c2755d48abad30/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5", size = 28220, upload-time = "2024-02-02T16:30:24.76Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/40/2e73e7d532d030b1e41180807a80d564eda53babaf04d65e15c1cf897e40/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c", size = 27756, upload-time = "2024-02-02T16:30:25.877Z" },
-    { url = "https://files.pythonhosted.org/packages/18/46/5dca760547e8c59c5311b332f70605d24c99d1303dd9a6e1fc3ed0d73561/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f", size = 33988, upload-time = "2024-02-02T16:30:26.935Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/c5/27febe918ac36397919cd4a67d5579cbbfa8da027fa1238af6285bb368ea/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a", size = 32718, upload-time = "2024-02-02T16:30:28.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/81/56e567126a2c2bc2684d6391332e357589a96a76cb9f8e5052d85cb0ead8/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f", size = 33317, upload-time = "2024-02-02T16:30:29.214Z" },
-    { url = "https://files.pythonhosted.org/packages/00/0b/23f4b2470accb53285c613a3ab9ec19dc944eaf53592cb6d9e2af8aa24cc/MarkupSafe-2.1.5-cp311-cp311-win32.whl", hash = "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906", size = 16670, upload-time = "2024-02-02T16:30:30.915Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a2/c78a06a9ec6d04b3445a949615c4c7ed86a0b2eb68e44e7541b9d57067cc/MarkupSafe-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617", size = 17224, upload-time = "2024-02-02T16:30:32.09Z" },
-    { url = "https://files.pythonhosted.org/packages/53/bd/583bf3e4c8d6a321938c13f49d44024dbe5ed63e0a7ba127e454a66da974/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1", size = 18215, upload-time = "2024-02-02T16:30:33.081Z" },
-    { url = "https://files.pythonhosted.org/packages/48/d6/e7cd795fc710292c3af3a06d80868ce4b02bfbbf370b7cee11d282815a2a/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4", size = 14069, upload-time = "2024-02-02T16:30:34.148Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b5/5d8ec796e2a08fc814a2c7d2584b55f889a55cf17dd1a90f2beb70744e5c/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee", size = 29452, upload-time = "2024-02-02T16:30:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5", size = 28462, upload-time = "2024-02-02T16:30:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/75/fd6cb2e68780f72d47e6671840ca517bda5ef663d30ada7616b0462ad1e3/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b", size = 27869, upload-time = "2024-02-02T16:30:37.834Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/81/147c477391c2750e8fc7705829f7351cf1cd3be64406edcf900dc633feb2/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a", size = 33906, upload-time = "2024-02-02T16:30:39.366Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ff/9a52b71839d7a256b563e85d11050e307121000dcebc97df120176b3ad93/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f", size = 32296, upload-time = "2024-02-02T16:30:40.413Z" },
-    { url = "https://files.pythonhosted.org/packages/88/07/2dc76aa51b481eb96a4c3198894f38b480490e834479611a4053fbf08623/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169", size = 33038, upload-time = "2024-02-02T16:30:42.243Z" },
-    { url = "https://files.pythonhosted.org/packages/96/0c/620c1fb3661858c0e37eb3cbffd8c6f732a67cd97296f725789679801b31/MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad", size = 16572, upload-time = "2024-02-02T16:30:43.326Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb", size = 17127, upload-time = "2024-02-02T16:30:44.418Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ff/2c942a82c35a49df5de3a630ce0a8456ac2969691b230e530ac12314364c/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a", size = 18192, upload-time = "2024-02-02T16:30:57.715Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/14/6f294b9c4f969d0c801a4615e221c1e084722ea6114ab2114189c5b8cbe0/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46", size = 14072, upload-time = "2024-02-02T16:30:58.844Z" },
-    { url = "https://files.pythonhosted.org/packages/81/d4/fd74714ed30a1dedd0b82427c02fa4deec64f173831ec716da11c51a50aa/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532", size = 26928, upload-time = "2024-02-02T16:30:59.922Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/bd/50319665ce81bb10e90d1cf76f9e1aa269ea6f7fa30ab4521f14d122a3df/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab", size = 26106, upload-time = "2024-02-02T16:31:01.582Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/6f/f2b0f675635b05f6afd5ea03c094557bdb8622fa8e673387444fe8d8e787/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68", size = 25781, upload-time = "2024-02-02T16:31:02.71Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e0/393467cf899b34a9d3678e78961c2c8cdf49fb902a959ba54ece01273fb1/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0", size = 30518, upload-time = "2024-02-02T16:31:04.392Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/02/5437e2ad33047290dafced9df741d9efc3e716b75583bbd73a9984f1b6f7/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4", size = 29669, upload-time = "2024-02-02T16:31:05.53Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/7d/968284145ffd9d726183ed6237c77938c021abacde4e073020f920e060b2/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3", size = 29933, upload-time = "2024-02-02T16:31:06.636Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/f3/ecb00fc8ab02b7beae8699f34db9357ae49d9f21d4d3de6f305f34fa949e/MarkupSafe-2.1.5-cp38-cp38-win32.whl", hash = "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff", size = 16656, upload-time = "2024-02-02T16:31:07.767Z" },
-    { url = "https://files.pythonhosted.org/packages/92/21/357205f03514a49b293e214ac39de01fadd0970a6e05e4bf1ddd0ffd0881/MarkupSafe-2.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029", size = 17206, upload-time = "2024-02-02T16:31:08.843Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/31/780bb297db036ba7b7bbede5e1d7f1e14d704ad4beb3ce53fb495d22bc62/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf", size = 18193, upload-time = "2024-02-02T16:31:10.155Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d77701bbef72892affe060cdacb7a2ed7fd68dae3b477a8642f15ad3b132/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2", size = 14073, upload-time = "2024-02-02T16:31:11.442Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a7/1e558b4f78454c8a3a0199292d96159eb4d091f983bc35ef258314fe7269/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8", size = 26486, upload-time = "2024-02-02T16:31:12.488Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5a/360da85076688755ea0cceb92472923086993e86b5613bbae9fbc14136b0/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3", size = 25685, upload-time = "2024-02-02T16:31:13.726Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/18/ae5a258e3401f9b8312f92b028c54d7026a97ec3ab20bfaddbdfa7d8cce8/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465", size = 25338, upload-time = "2024-02-02T16:31:14.812Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/cc/48206bd61c5b9d0129f4d75243b156929b04c94c09041321456fd06a876d/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e", size = 30439, upload-time = "2024-02-02T16:31:15.946Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/06/a41c112ab9ffdeeb5f77bc3e331fdadf97fa65e52e44ba31880f4e7f983c/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea", size = 29531, upload-time = "2024-02-02T16:31:17.13Z" },
-    { url = "https://files.pythonhosted.org/packages/02/8c/ab9a463301a50dab04d5472e998acbd4080597abc048166ded5c7aa768c8/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6", size = 29823, upload-time = "2024-02-02T16:31:18.247Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/29/9bc18da763496b055d8e98ce476c8e718dcfd78157e17f555ce6dd7d0895/MarkupSafe-2.1.5-cp39-cp39-win32.whl", hash = "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf", size = 16658, upload-time = "2024-02-02T16:31:19.583Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f8/4da07de16f10551ca1f640c92b5f316f9394088b183c6a57183df6de5ae4/MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5", size = 17211, upload-time = "2024-02-02T16:31:20.96Z" },
-]
-
-[[package]]
-name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
@@ -1030,25 +783,8 @@ wheels = [
 
 [[package]]
 name = "path"
-version = "17.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/a3/5dac44ce60ad6543578736a5729c5c2130cdac1c3117c61aad0583c2e3c6/path-17.0.0.tar.gz", hash = "sha256:e1540261d22df1416fb1b498b3b1ed5353a371a48fe197d66611bb01e7fab2d5", size = 49721, upload-time = "2024-07-27T10:46:56.433Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/49/5ffc63f96029e4f899d6caee9db40c445ded1bf15cb60b32d77363c2c8de/path-17.0.0-py3-none-any.whl", hash = "sha256:b7309739c569e30110a34c6c812e582c09ff504c43e1232817410181838918ed", size = 24831, upload-time = "2024-07-27T10:46:54.7Z" },
-]
-
-[[package]]
-name = "path"
 version = "17.1.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/52/a7bdd5ef8488977d354b7915d1e75009bebbd04f73eff14e52372d5e9435/path-17.1.1.tar.gz", hash = "sha256:2dfcbfec8b4d960f3469c52acf133113c2a8bf12ac7b98d629fa91af87248d42", size = 50528, upload-time = "2025-07-27T20:40:23.79Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/50/11c9ee1ede64b45d687fd36eb8768dafc57afc78b4d83396920cfd69ed30/path-17.1.1-py3-none-any.whl", hash = "sha256:ec7e136df29172e5030dd07e037d55f676bdb29d15bfa09b80da29d07d3b9303", size = 23936, upload-time = "2025-07-27T20:40:22.453Z" },
@@ -1056,23 +792,10 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.6"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload-time = "2024-09-17T19:06:50.688Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload-time = "2024-09-17T19:06:49.212Z" },
-]
-
-[[package]]
-name = "platformdirs"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
 wheels = [
@@ -1093,25 +816,8 @@ wheels = [
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
-]
-
-[[package]]
-name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -1119,37 +825,17 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "cfgv", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "identify", version = "2.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "nodeenv", marker = "python_full_version < '3.9'" },
-    { name = "pyyaml", marker = "python_full_version < '3.9'" },
-    { name = "virtualenv", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b3/4ae08d21eb097162f5aad37f4585f8069a86402ed7f5362cc9ae097f9572/pre_commit-3.5.0.tar.gz", hash = "sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32", size = 177079, upload-time = "2023-10-13T15:57:48.334Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/75/526915fedf462e05eeb1c75ceaf7e3f9cde7b5ce6f62740fe5f7f19a0050/pre_commit-3.5.0-py2.py3-none-any.whl", hash = "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660", size = 203698, upload-time = "2023-10-13T15:57:46.378Z" },
-]
-
-[[package]]
-name = "pre-commit"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "cfgv", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "identify", version = "2.6.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "nodeenv", marker = "python_full_version == '3.9.*'" },
-    { name = "pyyaml", marker = "python_full_version == '3.9.*'" },
-    { name = "virtualenv", marker = "python_full_version == '3.9.*'" },
+    { name = "cfgv", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "identify", version = "2.6.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "nodeenv", marker = "python_full_version < '3.10'" },
+    { name = "pyyaml", marker = "python_full_version < '3.10'" },
+    { name = "virtualenv", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
 wheels = [
@@ -1181,11 +867,9 @@ version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
-    { name = "identify", version = "2.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "identify", version = "2.6.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "identify", version = "2.6.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "identify", version = "2.6.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "path", version = "17.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "path", version = "17.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "path" },
     { name = "pyyaml" },
     { name = "restructuredtext-lint" },
     { name = "tomli" },
@@ -1194,33 +878,25 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "freezegun" },
-    { name = "pre-commit", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-cov", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-cov" },
     { name = "pytest-git" },
-    { name = "pytest-mock", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-mock", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-mock" },
     { name = "python-semantic-release" },
     { name = "ruff" },
 ]
 test = [
     { name = "freezegun" },
-    { name = "pre-commit", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-cov", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-cov" },
     { name = "pytest-git" },
-    { name = "pytest-mock", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-mock", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-mock" },
 ]
 
 [package.metadata]
@@ -1255,35 +931,13 @@ test = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.6"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "annotated-types", marker = "python_full_version < '3.9'" },
-    { name = "pydantic-core", version = "2.27.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681, upload-time = "2025-01-24T01:42:12.693Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696, upload-time = "2025-01-24T01:42:10.371Z" },
-]
-
-[[package]]
-name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version >= '3.9'" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.9'" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -1292,128 +946,10 @@ wheels = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443, upload-time = "2024-12-18T11:31:54.917Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/bc/fed5f74b5d802cf9a03e83f60f18864e90e3aed7223adaca5ffb7a8d8d64/pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa", size = 1895938, upload-time = "2024-12-18T11:27:14.406Z" },
-    { url = "https://files.pythonhosted.org/packages/71/2a/185aff24ce844e39abb8dd680f4e959f0006944f4a8a0ea372d9f9ae2e53/pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c", size = 1815684, upload-time = "2024-12-18T11:27:16.489Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/43/fafabd3d94d159d4f1ed62e383e264f146a17dd4d48453319fd782e7979e/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a", size = 1829169, upload-time = "2024-12-18T11:27:22.16Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/d1/f2dfe1a2a637ce6800b799aa086d079998959f6f1215eb4497966efd2274/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5", size = 1867227, upload-time = "2024-12-18T11:27:25.097Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/39/e06fcbcc1c785daa3160ccf6c1c38fea31f5754b756e34b65f74e99780b5/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c", size = 2037695, upload-time = "2024-12-18T11:27:28.656Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/67/61291ee98e07f0650eb756d44998214231f50751ba7e13f4f325d95249ab/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7", size = 2741662, upload-time = "2024-12-18T11:27:30.798Z" },
-    { url = "https://files.pythonhosted.org/packages/32/90/3b15e31b88ca39e9e626630b4c4a1f5a0dfd09076366f4219429e6786076/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a", size = 1993370, upload-time = "2024-12-18T11:27:33.692Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/83/c06d333ee3a67e2e13e07794995c1535565132940715931c1c43bfc85b11/pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236", size = 1996813, upload-time = "2024-12-18T11:27:37.111Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f7/89be1c8deb6e22618a74f0ca0d933fdcb8baa254753b26b25ad3acff8f74/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962", size = 2005287, upload-time = "2024-12-18T11:27:40.566Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7d/8eb3e23206c00ef7feee17b83a4ffa0a623eb1a9d382e56e4aa46fd15ff2/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9", size = 2128414, upload-time = "2024-12-18T11:27:43.757Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/99/fe80f3ff8dd71a3ea15763878d464476e6cb0a2db95ff1c5c554133b6b83/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af", size = 2155301, upload-time = "2024-12-18T11:27:47.36Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/a3/e50460b9a5789ca1451b70d4f52546fa9e2b420ba3bfa6100105c0559238/pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4", size = 1816685, upload-time = "2024-12-18T11:27:50.508Z" },
-    { url = "https://files.pythonhosted.org/packages/57/4c/a8838731cb0f2c2a39d3535376466de6049034d7b239c0202a64aaa05533/pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31", size = 1982876, upload-time = "2024-12-18T11:27:53.54Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc", size = 1893421, upload-time = "2024-12-18T11:27:55.409Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7", size = 1814998, upload-time = "2024-12-18T11:27:57.252Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15", size = 1826167, upload-time = "2024-12-18T11:27:59.146Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306", size = 1865071, upload-time = "2024-12-18T11:28:02.625Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99", size = 2036244, upload-time = "2024-12-18T11:28:04.442Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459", size = 2737470, upload-time = "2024-12-18T11:28:07.679Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048", size = 1992291, upload-time = "2024-12-18T11:28:10.297Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d", size = 1994613, upload-time = "2024-12-18T11:28:13.362Z" },
-    { url = "https://files.pythonhosted.org/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b", size = 2002355, upload-time = "2024-12-18T11:28:16.587Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474", size = 2126661, upload-time = "2024-12-18T11:28:18.407Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6", size = 2153261, upload-time = "2024-12-18T11:28:21.471Z" },
-    { url = "https://files.pythonhosted.org/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c", size = 1812361, upload-time = "2024-12-18T11:28:23.53Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc", size = 1982484, upload-time = "2024-12-18T11:28:25.391Z" },
-    { url = "https://files.pythonhosted.org/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4", size = 1867102, upload-time = "2024-12-18T11:28:28.593Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127, upload-time = "2024-12-18T11:28:30.346Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340, upload-time = "2024-12-18T11:28:32.521Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900, upload-time = "2024-12-18T11:28:34.507Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177, upload-time = "2024-12-18T11:28:36.488Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046, upload-time = "2024-12-18T11:28:39.409Z" },
-    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386, upload-time = "2024-12-18T11:28:41.221Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060, upload-time = "2024-12-18T11:28:44.709Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870, upload-time = "2024-12-18T11:28:46.839Z" },
-    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822, upload-time = "2024-12-18T11:28:48.896Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364, upload-time = "2024-12-18T11:28:50.755Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303, upload-time = "2024-12-18T11:28:54.122Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064, upload-time = "2024-12-18T11:28:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046, upload-time = "2024-12-18T11:28:58.107Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092, upload-time = "2024-12-18T11:29:01.335Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709, upload-time = "2024-12-18T11:29:03.193Z" },
-    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273, upload-time = "2024-12-18T11:29:05.306Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027, upload-time = "2024-12-18T11:29:07.294Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888, upload-time = "2024-12-18T11:29:09.249Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738, upload-time = "2024-12-18T11:29:11.23Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138, upload-time = "2024-12-18T11:29:16.396Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025, upload-time = "2024-12-18T11:29:20.25Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633, upload-time = "2024-12-18T11:29:23.877Z" },
-    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404, upload-time = "2024-12-18T11:29:25.872Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130, upload-time = "2024-12-18T11:29:29.252Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946, upload-time = "2024-12-18T11:29:31.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387, upload-time = "2024-12-18T11:29:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453, upload-time = "2024-12-18T11:29:35.533Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186, upload-time = "2024-12-18T11:29:37.649Z" },
-    { url = "https://files.pythonhosted.org/packages/43/53/13e9917fc69c0a4aea06fd63ed6a8d6cda9cf140ca9584d49c1650b0ef5e/pydantic_core-2.27.2-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d3e8d504bdd3f10835468f29008d72fc8359d95c9c415ce6e767203db6127506", size = 1899595, upload-time = "2024-12-18T11:29:40.887Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/20/26c549249769ed84877f862f7bb93f89a6ee08b4bee1ed8781616b7fbb5e/pydantic_core-2.27.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:521eb9b7f036c9b6187f0b47318ab0d7ca14bd87f776240b90b21c1f4f149320", size = 1775010, upload-time = "2024-12-18T11:29:44.823Z" },
-    { url = "https://files.pythonhosted.org/packages/35/eb/8234e05452d92d2b102ffa1b56d801c3567e628fdc63f02080fdfc68fd5e/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85210c4d99a0114f5a9481b44560d7d1e35e32cc5634c656bc48e590b669b145", size = 1830727, upload-time = "2024-12-18T11:29:46.904Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/df/59f915c8b929d5f61e5a46accf748a87110ba145156f9326d1a7d28912b2/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d716e2e30c6f140d7560ef1538953a5cd1a87264c737643d481f2779fc247fe1", size = 1868393, upload-time = "2024-12-18T11:29:49.098Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/52/81cf4071dca654d485c277c581db368b0c95b2b883f4d7b736ab54f72ddf/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f66d89ba397d92f840f8654756196d93804278457b5fbede59598a1f9f90b228", size = 2040300, upload-time = "2024-12-18T11:29:51.43Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/00/05197ce1614f5c08d7a06e1d39d5d8e704dc81971b2719af134b844e2eaf/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:669e193c1c576a58f132e3158f9dfa9662969edb1a250c54d8fa52590045f046", size = 2738785, upload-time = "2024-12-18T11:29:55.001Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a3/5f19bc495793546825ab160e530330c2afcee2281c02b5ffafd0b32ac05e/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdbe7629b996647b99c01b37f11170a57ae675375b14b8c13b8518b8320ced5", size = 1996493, upload-time = "2024-12-18T11:29:57.13Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/e8/e0102c2ec153dc3eed88aea03990e1b06cfbca532916b8a48173245afe60/pydantic_core-2.27.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d262606bf386a5ba0b0af3b97f37c83d7011439e3dc1a9298f21efb292e42f1a", size = 1998544, upload-time = "2024-12-18T11:30:00.681Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a3/4be70845b555bd80aaee9f9812a7cf3df81550bce6dadb3cfee9c5d8421d/pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:cabb9bcb7e0d97f74df8646f34fc76fbf793b7f6dc2438517d7a9e50eee4f14d", size = 2007449, upload-time = "2024-12-18T11:30:02.985Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/9f/b779ed2480ba355c054e6d7ea77792467631d674b13d8257085a4bc7dcda/pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_armv7l.whl", hash = "sha256:d2d63f1215638d28221f664596b1ccb3944f6e25dd18cd3b86b0a4c408d5ebb9", size = 2129460, upload-time = "2024-12-18T11:30:06.55Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f0/a6ab0681f6e95260c7fbf552874af7302f2ea37b459f9b7f00698f875492/pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bca101c00bff0adb45a833f8451b9105d9df18accb8743b08107d7ada14bd7da", size = 2159609, upload-time = "2024-12-18T11:30:09.428Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/2b/e1059506795104349712fbca647b18b3f4a7fd541c099e6259717441e1e0/pydantic_core-2.27.2-cp38-cp38-win32.whl", hash = "sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b", size = 1819886, upload-time = "2024-12-18T11:30:11.777Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/6d/df49c17f024dfc58db0bacc7b03610058018dd2ea2eaf748ccbada4c3d06/pydantic_core-2.27.2-cp38-cp38-win_amd64.whl", hash = "sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad", size = 1980773, upload-time = "2024-12-18T11:30:14.828Z" },
-    { url = "https://files.pythonhosted.org/packages/27/97/3aef1ddb65c5ccd6eda9050036c956ff6ecbfe66cb7eb40f280f121a5bb0/pydantic_core-2.27.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c10eb4f1659290b523af58fa7cffb452a61ad6ae5613404519aee4bfbf1df993", size = 1896475, upload-time = "2024-12-18T11:30:18.316Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/d3/5668da70e373c9904ed2f372cb52c0b996426f302e0dee2e65634c92007d/pydantic_core-2.27.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef592d4bad47296fb11f96cd7dc898b92e795032b4894dfb4076cfccd43a9308", size = 1772279, upload-time = "2024-12-18T11:30:20.547Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/9e/e44b8cb0edf04a2f0a1f6425a65ee089c1d6f9c4c2dcab0209127b6fdfc2/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c61709a844acc6bf0b7dce7daae75195a10aac96a596ea1b776996414791ede4", size = 1829112, upload-time = "2024-12-18T11:30:23.255Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/90/1160d7ac700102effe11616e8119e268770f2a2aa5afb935f3ee6832987d/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c5f762659e47fdb7b16956c71598292f60a03aa92f8b6351504359dbdba6cf", size = 1866780, upload-time = "2024-12-18T11:30:25.742Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/33/13983426df09a36d22c15980008f8d9c77674fc319351813b5a2739b70f3/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c9775e339e42e79ec99c441d9730fccf07414af63eac2f0e48e08fd38a64d76", size = 2037943, upload-time = "2024-12-18T11:30:28.036Z" },
-    { url = "https://files.pythonhosted.org/packages/01/d7/ced164e376f6747e9158c89988c293cd524ab8d215ae4e185e9929655d5c/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57762139821c31847cfb2df63c12f725788bd9f04bc2fb392790959b8f70f118", size = 2740492, upload-time = "2024-12-18T11:30:30.412Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/1f/3dc6e769d5b7461040778816aab2b00422427bcaa4b56cc89e9c653b2605/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d1e85068e818c73e048fe28cfc769040bb1f475524f4745a5dc621f75ac7630", size = 1995714, upload-time = "2024-12-18T11:30:34.358Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d7/a0bd09bc39283530b3f7c27033a814ef254ba3bd0b5cfd040b7abf1fe5da/pydantic_core-2.27.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:097830ed52fd9e427942ff3b9bc17fab52913b2f50f2880dc4a5611446606a54", size = 1997163, upload-time = "2024-12-18T11:30:37.979Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/bb/2db4ad1762e1c5699d9b857eeb41959191980de6feb054e70f93085e1bcd/pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:044a50963a614ecfae59bb1eaf7ea7efc4bc62f49ed594e18fa1e5d953c40e9f", size = 2005217, upload-time = "2024-12-18T11:30:40.367Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5f/23a5a3e7b8403f8dd8fc8a6f8b49f6b55c7d715b77dcf1f8ae919eeb5628/pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:4e0b4220ba5b40d727c7f879eac379b822eee5d8fff418e9d3381ee45b3b0362", size = 2127899, upload-time = "2024-12-18T11:30:42.737Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/ae/aa38bb8dd3d89c2f1d8362dd890ee8f3b967330821d03bbe08fa01ce3766/pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e4f4bb20d75e9325cc9696c6802657b58bc1dbbe3022f32cc2b2b632c3fbb96", size = 2155726, upload-time = "2024-12-18T11:30:45.279Z" },
-    { url = "https://files.pythonhosted.org/packages/98/61/4f784608cc9e98f70839187117ce840480f768fed5d386f924074bf6213c/pydantic_core-2.27.2-cp39-cp39-win32.whl", hash = "sha256:cca63613e90d001b9f2f9a9ceb276c308bfa2a43fafb75c8031c4f66039e8c6e", size = 1817219, upload-time = "2024-12-18T11:30:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/57/82/bb16a68e4a1a858bb3768c2c8f1ff8d8978014e16598f001ea29a25bf1d1/pydantic_core-2.27.2-cp39-cp39-win_amd64.whl", hash = "sha256:77d1bca19b0f7021b3a982e6f903dcd5b2b06076def36a652e3907f596e29f67", size = 1985382, upload-time = "2024-12-18T11:30:51.871Z" },
-    { url = "https://files.pythonhosted.org/packages/46/72/af70981a341500419e67d5cb45abe552a7c74b66326ac8877588488da1ac/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e", size = 1891159, upload-time = "2024-12-18T11:30:54.382Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/3d/c5913cccdef93e0a6a95c2d057d2c2cba347815c845cda79ddd3c0f5e17d/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8", size = 1768331, upload-time = "2024-12-18T11:30:58.178Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f0/a3ae8fbee269e4934f14e2e0e00928f9346c5943174f2811193113e58252/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3", size = 1822467, upload-time = "2024-12-18T11:31:00.6Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/7a/7bbf241a04e9f9ea24cd5874354a83526d639b02674648af3f350554276c/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f", size = 1979797, upload-time = "2024-12-18T11:31:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/5f/4784c6107731f89e0005a92ecb8a2efeafdb55eb992b8e9d0a2be5199335/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133", size = 1987839, upload-time = "2024-12-18T11:31:09.775Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a7/61246562b651dff00de86a5f01b6e4befb518df314c54dec187a78d81c84/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc", size = 1998861, upload-time = "2024-12-18T11:31:13.469Z" },
-    { url = "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50", size = 2116582, upload-time = "2024-12-18T11:31:17.423Z" },
-    { url = "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9", size = 2151985, upload-time = "2024-12-18T11:31:19.901Z" },
-    { url = "https://files.pythonhosted.org/packages/63/37/3e32eeb2a451fddaa3898e2163746b0cffbbdbb4740d38372db0490d67f3/pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151", size = 2004715, upload-time = "2024-12-18T11:31:22.821Z" },
-    { url = "https://files.pythonhosted.org/packages/29/0e/dcaea00c9dbd0348b723cae82b0e0c122e0fa2b43fa933e1622fd237a3ee/pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c33939a82924da9ed65dab5a65d427205a73181d8098e79b6b426bdf8ad4e656", size = 1891733, upload-time = "2024-12-18T11:31:26.876Z" },
-    { url = "https://files.pythonhosted.org/packages/86/d3/e797bba8860ce650272bda6383a9d8cad1d1c9a75a640c9d0e848076f85e/pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278", size = 1768375, upload-time = "2024-12-18T11:31:29.276Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f7/f847b15fb14978ca2b30262548f5fc4872b2724e90f116393eb69008299d/pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c817e2b40aba42bac6f457498dacabc568c3b7a986fc9ba7c8d9d260b71485fb", size = 1822307, upload-time = "2024-12-18T11:31:33.123Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/63/ed80ec8255b587b2f108e514dc03eed1546cd00f0af281e699797f373f38/pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:251136cdad0cb722e93732cb45ca5299fb56e1344a833640bf93b2803f8d1bfd", size = 1979971, upload-time = "2024-12-18T11:31:35.755Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/6d/6d18308a45454a0de0e975d70171cadaf454bc7a0bf86b9c7688e313f0bb/pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2088237af596f0a524d3afc39ab3b036e8adb054ee57cbb1dcf8e09da5b29cc", size = 1987616, upload-time = "2024-12-18T11:31:38.534Z" },
-    { url = "https://files.pythonhosted.org/packages/82/8a/05f8780f2c1081b800a7ca54c1971e291c2d07d1a50fb23c7e4aef4ed403/pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d4041c0b966a84b4ae7a09832eb691a35aec90910cd2dbe7a208de59be77965b", size = 1998943, upload-time = "2024-12-18T11:31:41.853Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/3e/fe5b6613d9e4c0038434396b46c5303f5ade871166900b357ada4766c5b7/pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:8083d4e875ebe0b864ffef72a4304827015cff328a1be6e22cc850753bfb122b", size = 2116654, upload-time = "2024-12-18T11:31:44.756Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ad/28869f58938fad8cc84739c4e592989730bfb69b7c90a8fff138dff18e1e/pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f141ee28a0ad2123b6611b6ceff018039df17f32ada8b534e6aa039545a3efb2", size = 2152292, upload-time = "2024-12-18T11:31:48.613Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/0c/c5c5cd3689c32ed1fe8c5d234b079c12c281c051759770c05b8bed6412b5/pydantic_core-2.27.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7d0c8399fcc1848491f00e0314bd59fb34a9c008761bcb422a057670c3f65e35", size = 2004961, upload-time = "2024-12-18T11:31:52.446Z" },
-]
-
-[[package]]
-name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -1550,40 +1086,19 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "packaging", marker = "python_full_version < '3.9'" },
-    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
-]
-
-[[package]]
-name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.9.*' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.9.*'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "packaging", marker = "python_full_version == '3.9.*'" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "pygments", marker = "python_full_version == '3.9.*'" },
-    { name = "tomli", marker = "python_full_version == '3.9.*'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -1602,7 +1117,7 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
     { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
     { name = "pygments", marker = "python_full_version >= '3.10'" },
     { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
@@ -1613,34 +1128,13 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042, upload-time = "2024-03-24T20:16:34.856Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990, upload-time = "2024-03-24T20:16:32.444Z" },
-]
-
-[[package]]
-name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version == '3.9.*'" },
+    { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.13.4", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pluggy" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
@@ -1654,8 +1148,7 @@ version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitpython" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-shutil" },
 ]
@@ -1666,30 +1159,10 @@ wheels = [
 
 [[package]]
 name = "pytest-mock"
-version = "3.14.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241, upload-time = "2025-05-26T13:58:45.167Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923, upload-time = "2025-05-26T13:58:43.487Z" },
-]
-
-[[package]]
-name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
@@ -1703,12 +1176,10 @@ version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "execnet" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "six" },
-    { name = "termcolor", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "termcolor", version = "3.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "termcolor", version = "3.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "termcolor", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/8d/5a60eeced74608fd2304dafc9e26815988714f8a2cfa72da99c8c3c85515/pytest-shutil-1.8.1.tar.gz", hash = "sha256:7dcc02e8a372098d51a98737e7f662e6edfd75cec7070a11e904141de49d866b", size = 37554, upload-time = "2024-11-29T19:34:17.066Z" }
@@ -1730,32 +1201,11 @@ wheels = [
 
 [[package]]
 name = "python-gitlab"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "requests-toolbelt", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/ea/e2cde926d63526935c1df259177371a195089b631d67a577fe5c39fbc7e1/python_gitlab-4.13.0.tar.gz", hash = "sha256:576bfb0901faca0c6b2d1ff2592e02944a6ec3e086c3129fb43c2a0df56a1c67", size = 484996, upload-time = "2024-10-08T13:28:48.755Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/5e/5fb4dcae9f5af5463c16952823d446ca449cce920efe8669871f600f0ab9/python_gitlab-4.13.0-py3-none-any.whl", hash = "sha256:8299a054fb571da16e1a8c1868fff01f34ac41ea1410c713a4647b3bbb2aa279", size = 145254, upload-time = "2024-10-08T13:28:45.839Z" },
-]
-
-[[package]]
-name = "python-gitlab"
 version = "6.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "requests-toolbelt", marker = "python_full_version >= '3.9'" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/bd/b30f1d3b303cb5d3c72e2d57a847d699e8573cbdfd67ece5f1795e49da1c/python_gitlab-6.5.0.tar.gz", hash = "sha256:97553652d94b02de343e9ca92782239aa2b5f6594c5482331a9490d9d5e8737d", size = 400591, upload-time = "2025-10-17T21:40:02.89Z" }
 wheels = [
@@ -1772,15 +1222,11 @@ dependencies = [
     { name = "deprecated" },
     { name = "dotty-dict" },
     { name = "gitpython" },
-    { name = "importlib-resources", version = "6.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-resources", version = "6.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "importlib-resources" },
     { name = "jinja2" },
-    { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "python-gitlab", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "python-gitlab", version = "6.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pydantic" },
+    { name = "python-gitlab" },
+    { name = "requests" },
     { name = "rich" },
     { name = "shellingham" },
     { name = "tomlkit" },
@@ -1796,13 +1242,6 @@ version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/a2/09f67a3589cb4320fb5ce90d3fd4c9752636b8b6ad8f34b54d76c5a54693/PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f", size = 186824, upload-time = "2025-09-29T20:27:35.918Z" },
-    { url = "https://files.pythonhosted.org/packages/02/72/d972384252432d57f248767556ac083793292a4adf4e2d85dfe785ec2659/PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4", size = 795069, upload-time = "2025-09-29T20:27:38.15Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/3b/6c58ac0fa7c4e1b35e48024eb03d00817438310447f93ef4431673c24138/PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3", size = 862585, upload-time = "2025-09-29T20:27:39.715Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a2/b725b61ac76a75583ae7104b3209f75ea44b13cfd026aa535ece22b7f22e/PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6", size = 806018, upload-time = "2025-09-29T20:27:41.444Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b0/b2227677b2d1036d84f5ee95eb948e7af53d59fe3e4328784e4d290607e0/PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369", size = 802822, upload-time = "2025-09-29T20:27:42.885Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a5/718a8ea22521e06ef19f91945766a892c5ceb1855df6adbde67d997ea7ed/PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295", size = 143744, upload-time = "2025-09-29T20:27:44.487Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b2/2b69cee94c9eb215216fc05778675c393e3aa541131dc910df8e52c83776/PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b", size = 160082, upload-time = "2025-09-29T20:27:46.049Z" },
     { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
     { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
     { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
@@ -1872,36 +1311,13 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.9'" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.9'" },
-    { name = "idna", marker = "python_full_version < '3.9'" },
-    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
-]
-
-[[package]]
-name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.9'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.9'" },
-    { name = "idna", marker = "python_full_version >= '3.9'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -1913,8 +1329,7 @@ name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -1926,8 +1341,7 @@ name = "restructuredtext-lint"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", version = "0.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "docutils" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/e6/eefcad2228f4124f17e01064428fbcd0ade06a274f3063ce3a126a569d6b/restructuredtext_lint-2.0.2.tar.gz", hash = "sha256:dd25209b9e0b726929d8306339faf723734a3137db382bcf27294fa18a6bc52b", size = 17494, upload-time = "2025-11-23T08:05:18.585Z" }
 wheels = [
@@ -2002,23 +1416,10 @@ wheels = [
 
 [[package]]
 name = "termcolor"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/56/d7d66a84f96d804155f6ff2873d065368b25a07222a6fd51c4f24ef6d764/termcolor-2.4.0.tar.gz", hash = "sha256:aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a", size = 12664, upload-time = "2023-12-01T11:04:51.66Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/5f/8c716e47b3a50cbd7c146f45881e11d9414def768b7cd9c5e6650ec2a80a/termcolor-2.4.0-py3-none-any.whl", hash = "sha256:9297c0df9c99445c2412e832e882a7884038a25617c60cea2ad69488d4040d63", size = 7719, upload-time = "2023-12-01T11:04:50.019Z" },
-]
-
-[[package]]
-name = "termcolor"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/6c/3d75c196ac07ac8749600b60b03f4f6094d54e132c4d94ebac6ee0e0add0/termcolor-3.1.0.tar.gz", hash = "sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970", size = 14324, upload-time = "2025-04-30T11:37:53.791Z" }
 wheels = [
@@ -2102,25 +1503,8 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
-]
-
-[[package]]
-name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -2131,7 +1515,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -2140,25 +1524,8 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
-]
-
-[[package]]
-name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
@@ -2170,14 +1537,11 @@ version = "20.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
-    { name = "filelock", version = "3.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "filelock", version = "3.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "platformdirs", version = "4.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/54/809199edc537dbace273495ac0884d13df26436e910a5ed4d0ec0a69806b/virtualenv-20.39.0.tar.gz", hash = "sha256:a15f0cebd00d50074fd336a169d53422436a12dfe15149efec7072cfe817df8b", size = 5869141, upload-time = "2026-02-23T18:09:13.349Z" }
 wheels = [
@@ -2186,130 +1550,8 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/2a/6de8a50cb435b7f42c46126cf1a54b2aab81784e74c8595c8e025e8f36d3/wrapt-2.0.1.tar.gz", hash = "sha256:9c9c635e78497cacb81e84f8b11b23e0aacac7a136e73b8e5b2109a1d9fc468f", size = 82040, upload-time = "2025-11-07T00:45:33.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/0d/12d8c803ed2ce4e5e7d5b9f5f602721f9dfef82c95959f3ce97fa584bb5c/wrapt-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:64b103acdaa53b7caf409e8d45d39a8442fe6dcfec6ba3f3d141e0cc2b5b4dbd", size = 77481, upload-time = "2025-11-07T00:43:11.103Z" },
-    { url = "https://files.pythonhosted.org/packages/05/3e/4364ebe221ebf2a44d9fc8695a19324692f7dd2795e64bd59090856ebf12/wrapt-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:91bcc576260a274b169c3098e9a3519fb01f2989f6d3d386ef9cbf8653de1374", size = 60692, upload-time = "2025-11-07T00:43:13.697Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ff/ae2a210022b521f86a8ddcdd6058d137c051003812b0388a5e9a03d3fe10/wrapt-2.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ab594f346517010050126fcd822697b25a7031d815bb4fbc238ccbe568216489", size = 61574, upload-time = "2025-11-07T00:43:14.967Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/93/5cf92edd99617095592af919cb81d4bff61c5dbbb70d3c92099425a8ec34/wrapt-2.0.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:36982b26f190f4d737f04a492a68accbfc6fa042c3f42326fdfbb6c5b7a20a31", size = 113688, upload-time = "2025-11-07T00:43:18.275Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/0a/e38fc0cee1f146c9fb266d8ef96ca39fb14a9eef165383004019aa53f88a/wrapt-2.0.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23097ed8bc4c93b7bf36fa2113c6c733c976316ce0ee2c816f64ca06102034ef", size = 115698, upload-time = "2025-11-07T00:43:19.407Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/85/bef44ea018b3925fb0bcbe9112715f665e4d5309bd945191da814c314fd1/wrapt-2.0.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8bacfe6e001749a3b64db47bcf0341da757c95959f592823a93931a422395013", size = 112096, upload-time = "2025-11-07T00:43:16.5Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/0b/733a2376e413117e497aa1a5b1b78e8f3a28c0e9537d26569f67d724c7c5/wrapt-2.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8ec3303e8a81932171f455f792f8df500fc1a09f20069e5c16bd7049ab4e8e38", size = 114878, upload-time = "2025-11-07T00:43:20.81Z" },
-    { url = "https://files.pythonhosted.org/packages/da/03/d81dcb21bbf678fcda656495792b059f9d56677d119ca022169a12542bd0/wrapt-2.0.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3f373a4ab5dbc528a94334f9fe444395b23c2f5332adab9ff4ea82f5a9e33bc1", size = 111298, upload-time = "2025-11-07T00:43:22.229Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d5/5e623040e8056e1108b787020d56b9be93dbbf083bf2324d42cde80f3a19/wrapt-2.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f49027b0b9503bf6c8cdc297ca55006b80c2f5dd36cecc72c6835ab6e10e8a25", size = 113361, upload-time = "2025-11-07T00:43:24.301Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f3/de535ccecede6960e28c7b722e5744846258111d6c9f071aa7578ea37ad3/wrapt-2.0.1-cp310-cp310-win32.whl", hash = "sha256:8330b42d769965e96e01fa14034b28a2a7600fbf7e8f0cc90ebb36d492c993e4", size = 58035, upload-time = "2025-11-07T00:43:28.96Z" },
-    { url = "https://files.pythonhosted.org/packages/21/15/39d3ca5428a70032c2ec8b1f1c9d24c32e497e7ed81aed887a4998905fcc/wrapt-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:1218573502a8235bb8a7ecaed12736213b22dcde9feab115fa2989d42b5ded45", size = 60383, upload-time = "2025-11-07T00:43:25.804Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c2/dfd23754b7f7a4dce07e08f4309c4e10a40046a83e9ae1800f2e6b18d7c1/wrapt-2.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:eda8e4ecd662d48c28bb86be9e837c13e45c58b8300e43ba3c9b4fa9900302f7", size = 58894, upload-time = "2025-11-07T00:43:27.074Z" },
-    { url = "https://files.pythonhosted.org/packages/98/60/553997acf3939079dab022e37b67b1904b5b0cc235503226898ba573b10c/wrapt-2.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e17283f533a0d24d6e5429a7d11f250a58d28b4ae5186f8f47853e3e70d2590", size = 77480, upload-time = "2025-11-07T00:43:30.573Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/50/e5b3d30895d77c52105c6d5cbf94d5b38e2a3dd4a53d22d246670da98f7c/wrapt-2.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:85df8d92158cb8f3965aecc27cf821461bb5f40b450b03facc5d9f0d4d6ddec6", size = 60690, upload-time = "2025-11-07T00:43:31.594Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/40/660b2898703e5cbbb43db10cdefcc294274458c3ca4c68637c2b99371507/wrapt-2.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1be685ac7700c966b8610ccc63c3187a72e33cab53526a27b2a285a662cd4f7", size = 61578, upload-time = "2025-11-07T00:43:32.918Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/36/825b44c8a10556957bc0c1d84c7b29a40e05fcf1873b6c40aa9dbe0bd972/wrapt-2.0.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:df0b6d3b95932809c5b3fecc18fda0f1e07452d05e2662a0b35548985f256e28", size = 114115, upload-time = "2025-11-07T00:43:35.605Z" },
-    { url = "https://files.pythonhosted.org/packages/83/73/0a5d14bb1599677304d3c613a55457d34c344e9b60eda8a737c2ead7619e/wrapt-2.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da7384b0e5d4cae05c97cd6f94faaf78cc8b0f791fc63af43436d98c4ab37bb", size = 116157, upload-time = "2025-11-07T00:43:37.058Z" },
-    { url = "https://files.pythonhosted.org/packages/01/22/1c158fe763dbf0a119f985d945711d288994fe5514c0646ebe0eb18b016d/wrapt-2.0.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ec65a78fbd9d6f083a15d7613b2800d5663dbb6bb96003899c834beaa68b242c", size = 112535, upload-time = "2025-11-07T00:43:34.138Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/28/4f16861af67d6de4eae9927799b559c20ebdd4fe432e89ea7fe6fcd9d709/wrapt-2.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7de3cc939be0e1174969f943f3b44e0d79b6f9a82198133a5b7fc6cc92882f16", size = 115404, upload-time = "2025-11-07T00:43:39.214Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8b/7960122e625fad908f189b59c4aae2d50916eb4098b0fb2819c5a177414f/wrapt-2.0.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fb1a5b72cbd751813adc02ef01ada0b0d05d3dcbc32976ce189a1279d80ad4a2", size = 111802, upload-time = "2025-11-07T00:43:40.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/73/7881eee5ac31132a713ab19a22c9e5f1f7365c8b1df50abba5d45b781312/wrapt-2.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3fa272ca34332581e00bf7773e993d4f632594eb2d1b0b162a9038df0fd971dd", size = 113837, upload-time = "2025-11-07T00:43:42.921Z" },
-    { url = "https://files.pythonhosted.org/packages/45/00/9499a3d14e636d1f7089339f96c4409bbc7544d0889f12264efa25502ae8/wrapt-2.0.1-cp311-cp311-win32.whl", hash = "sha256:fc007fdf480c77301ab1afdbb6ab22a5deee8885f3b1ed7afcb7e5e84a0e27be", size = 58028, upload-time = "2025-11-07T00:43:47.369Z" },
-    { url = "https://files.pythonhosted.org/packages/70/5d/8f3d7eea52f22638748f74b102e38fdf88cb57d08ddeb7827c476a20b01b/wrapt-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:47434236c396d04875180171ee1f3815ca1eada05e24a1ee99546320d54d1d1b", size = 60385, upload-time = "2025-11-07T00:43:44.34Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e2/32195e57a8209003587bbbad44d5922f13e0ced2a493bb46ca882c5b123d/wrapt-2.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:837e31620e06b16030b1d126ed78e9383815cbac914693f54926d816d35d8edf", size = 58893, upload-time = "2025-11-07T00:43:46.161Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/73/8cb252858dc8254baa0ce58ce382858e3a1cf616acebc497cb13374c95c6/wrapt-2.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1fdbb34da15450f2b1d735a0e969c24bdb8d8924892380126e2a293d9902078c", size = 78129, upload-time = "2025-11-07T00:43:48.852Z" },
-    { url = "https://files.pythonhosted.org/packages/19/42/44a0db2108526ee6e17a5ab72478061158f34b08b793df251d9fbb9a7eb4/wrapt-2.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d32794fe940b7000f0519904e247f902f0149edbe6316c710a8562fb6738841", size = 61205, upload-time = "2025-11-07T00:43:50.402Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/8a/5b4b1e44b791c22046e90d9b175f9a7581a8cc7a0debbb930f81e6ae8e25/wrapt-2.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:386fb54d9cd903ee0012c09291336469eb7b244f7183d40dc3e86a16a4bace62", size = 61692, upload-time = "2025-11-07T00:43:51.678Z" },
-    { url = "https://files.pythonhosted.org/packages/11/53/3e794346c39f462bcf1f58ac0487ff9bdad02f9b6d5ee2dc84c72e0243b2/wrapt-2.0.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7b219cb2182f230676308cdcacd428fa837987b89e4b7c5c9025088b8a6c9faf", size = 121492, upload-time = "2025-11-07T00:43:55.017Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/7e/10b7b0e8841e684c8ca76b462a9091c45d62e8f2de9c4b1390b690eadf16/wrapt-2.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:641e94e789b5f6b4822bb8d8ebbdfc10f4e4eae7756d648b717d980f657a9eb9", size = 123064, upload-time = "2025-11-07T00:43:56.323Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/d1/3c1e4321fc2f5ee7fd866b2d822aa89b84495f28676fd976c47327c5b6aa/wrapt-2.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe21b118b9f58859b5ebaa4b130dee18669df4bd111daad082b7beb8799ad16b", size = 117403, upload-time = "2025-11-07T00:43:53.258Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/b0/d2f0a413cf201c8c2466de08414a15420a25aa83f53e647b7255cc2fab5d/wrapt-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17fb85fa4abc26a5184d93b3efd2dcc14deb4b09edcdb3535a536ad34f0b4dba", size = 121500, upload-time = "2025-11-07T00:43:57.468Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/45/bddb11d28ca39970a41ed48a26d210505120f925918592283369219f83cc/wrapt-2.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:b89ef9223d665ab255ae42cc282d27d69704d94be0deffc8b9d919179a609684", size = 116299, upload-time = "2025-11-07T00:43:58.877Z" },
-    { url = "https://files.pythonhosted.org/packages/81/af/34ba6dd570ef7a534e7eec0c25e2615c355602c52aba59413411c025a0cb/wrapt-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a453257f19c31b31ba593c30d997d6e5be39e3b5ad9148c2af5a7314061c63eb", size = 120622, upload-time = "2025-11-07T00:43:59.962Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/3e/693a13b4146646fb03254636f8bafd20c621955d27d65b15de07ab886187/wrapt-2.0.1-cp312-cp312-win32.whl", hash = "sha256:3e271346f01e9c8b1130a6a3b0e11908049fe5be2d365a5f402778049147e7e9", size = 58246, upload-time = "2025-11-07T00:44:03.169Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/36/715ec5076f925a6be95f37917b66ebbeaa1372d1862c2ccd7a751574b068/wrapt-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:2da620b31a90cdefa9cd0c2b661882329e2e19d1d7b9b920189956b76c564d75", size = 60492, upload-time = "2025-11-07T00:44:01.027Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/3e/62451cd7d80f65cc125f2b426b25fbb6c514bf6f7011a0c3904fc8c8df90/wrapt-2.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:aea9c7224c302bc8bfc892b908537f56c430802560e827b75ecbde81b604598b", size = 58987, upload-time = "2025-11-07T00:44:02.095Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/fe/41af4c46b5e498c90fc87981ab2972fbd9f0bccda597adb99d3d3441b94b/wrapt-2.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:47b0f8bafe90f7736151f61482c583c86b0693d80f075a58701dd1549b0010a9", size = 78132, upload-time = "2025-11-07T00:44:04.628Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/92/d68895a984a5ebbbfb175512b0c0aad872354a4a2484fbd5552e9f275316/wrapt-2.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cbeb0971e13b4bd81d34169ed57a6dda017328d1a22b62fda45e1d21dd06148f", size = 61211, upload-time = "2025-11-07T00:44:05.626Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/26/ba83dc5ae7cf5aa2b02364a3d9cf74374b86169906a1f3ade9a2d03cf21c/wrapt-2.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb7cffe572ad0a141a7886a1d2efa5bef0bf7fe021deeea76b3ab334d2c38218", size = 61689, upload-time = "2025-11-07T00:44:06.719Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/67/d7a7c276d874e5d26738c22444d466a3a64ed541f6ef35f740dbd865bab4/wrapt-2.0.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c8d60527d1ecfc131426b10d93ab5d53e08a09c5fa0175f6b21b3252080c70a9", size = 121502, upload-time = "2025-11-07T00:44:09.557Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/6b/806dbf6dd9579556aab22fc92908a876636e250f063f71548a8660382184/wrapt-2.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c654eafb01afac55246053d67a4b9a984a3567c3808bb7df2f8de1c1caba2e1c", size = 123110, upload-time = "2025-11-07T00:44:10.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/08/cdbb965fbe4c02c5233d185d070cabed2ecc1f1e47662854f95d77613f57/wrapt-2.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:98d873ed6c8b4ee2418f7afce666751854d6d03e3c0ec2a399bb039cd2ae89db", size = 117434, upload-time = "2025-11-07T00:44:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d1/6aae2ce39db4cb5216302fa2e9577ad74424dfbe315bd6669725569e048c/wrapt-2.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c9e850f5b7fc67af856ff054c71690d54fa940c3ef74209ad9f935b4f66a0233", size = 121533, upload-time = "2025-11-07T00:44:12.142Z" },
-    { url = "https://files.pythonhosted.org/packages/79/35/565abf57559fbe0a9155c29879ff43ce8bd28d2ca61033a3a3dd67b70794/wrapt-2.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e505629359cb5f751e16e30cf3f91a1d3ddb4552480c205947da415d597f7ac2", size = 116324, upload-time = "2025-11-07T00:44:13.28Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/e0/53ff5e76587822ee33e560ad55876d858e384158272cd9947abdd4ad42ca/wrapt-2.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2879af909312d0baf35f08edeea918ee3af7ab57c37fe47cb6a373c9f2749c7b", size = 120627, upload-time = "2025-11-07T00:44:14.431Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/7b/38df30fd629fbd7612c407643c63e80e1c60bcc982e30ceeae163a9800e7/wrapt-2.0.1-cp313-cp313-win32.whl", hash = "sha256:d67956c676be5a24102c7407a71f4126d30de2a569a1c7871c9f3cabc94225d7", size = 58252, upload-time = "2025-11-07T00:44:17.814Z" },
-    { url = "https://files.pythonhosted.org/packages/85/64/d3954e836ea67c4d3ad5285e5c8fd9d362fd0a189a2db622df457b0f4f6a/wrapt-2.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9ca66b38dd642bf90c59b6738af8070747b610115a39af2498535f62b5cdc1c3", size = 60500, upload-time = "2025-11-07T00:44:15.561Z" },
-    { url = "https://files.pythonhosted.org/packages/89/4e/3c8b99ac93527cfab7f116089db120fef16aac96e5f6cdb724ddf286086d/wrapt-2.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:5a4939eae35db6b6cec8e7aa0e833dcca0acad8231672c26c2a9ab7a0f8ac9c8", size = 58993, upload-time = "2025-11-07T00:44:16.65Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f4/eff2b7d711cae20d220780b9300faa05558660afb93f2ff5db61fe725b9a/wrapt-2.0.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a52f93d95c8d38fed0669da2ebdb0b0376e895d84596a976c15a9eb45e3eccb3", size = 82028, upload-time = "2025-11-07T00:44:18.944Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/67/cb945563f66fd0f61a999339460d950f4735c69f18f0a87ca586319b1778/wrapt-2.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4e54bbf554ee29fcceee24fa41c4d091398b911da6e7f5d7bffda963c9aed2e1", size = 62949, upload-time = "2025-11-07T00:44:20.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/ca/f63e177f0bbe1e5cf5e8d9b74a286537cd709724384ff20860f8f6065904/wrapt-2.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:908f8c6c71557f4deaa280f55d0728c3bca0960e8c3dd5ceeeafb3c19942719d", size = 63681, upload-time = "2025-11-07T00:44:21.345Z" },
-    { url = "https://files.pythonhosted.org/packages/39/a1/1b88fcd21fd835dca48b556daef750952e917a2794fa20c025489e2e1f0f/wrapt-2.0.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e2f84e9af2060e3904a32cea9bb6db23ce3f91cfd90c6b426757cf7cc01c45c7", size = 152696, upload-time = "2025-11-07T00:44:24.318Z" },
-    { url = "https://files.pythonhosted.org/packages/62/1c/d9185500c1960d9f5f77b9c0b890b7fc62282b53af7ad1b6bd779157f714/wrapt-2.0.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e3612dc06b436968dfb9142c62e5dfa9eb5924f91120b3c8ff501ad878f90eb3", size = 158859, upload-time = "2025-11-07T00:44:25.494Z" },
-    { url = "https://files.pythonhosted.org/packages/91/60/5d796ed0f481ec003220c7878a1d6894652efe089853a208ea0838c13086/wrapt-2.0.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d2d947d266d99a1477cd005b23cbd09465276e302515e122df56bb9511aca1b", size = 146068, upload-time = "2025-11-07T00:44:22.81Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f8/75282dd72f102ddbfba137e1e15ecba47b40acff32c08ae97edbf53f469e/wrapt-2.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:7d539241e87b650cbc4c3ac9f32c8d1ac8a54e510f6dca3f6ab60dcfd48c9b10", size = 155724, upload-time = "2025-11-07T00:44:26.634Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/27/fe39c51d1b344caebb4a6a9372157bdb8d25b194b3561b52c8ffc40ac7d1/wrapt-2.0.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:4811e15d88ee62dbf5c77f2c3ff3932b1e3ac92323ba3912f51fc4016ce81ecf", size = 144413, upload-time = "2025-11-07T00:44:27.939Z" },
-    { url = "https://files.pythonhosted.org/packages/83/2b/9f6b643fe39d4505c7bf926d7c2595b7cb4b607c8c6b500e56c6b36ac238/wrapt-2.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c1c91405fcf1d501fa5d55df21e58ea49e6b879ae829f1039faaf7e5e509b41e", size = 150325, upload-time = "2025-11-07T00:44:29.29Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/b6/20ffcf2558596a7f58a2e69c89597128781f0b88e124bf5a4cadc05b8139/wrapt-2.0.1-cp313-cp313t-win32.whl", hash = "sha256:e76e3f91f864e89db8b8d2a8311d57df93f01ad6bb1e9b9976d1f2e83e18315c", size = 59943, upload-time = "2025-11-07T00:44:33.211Z" },
-    { url = "https://files.pythonhosted.org/packages/87/6a/0e56111cbb3320151eed5d3821ee1373be13e05b376ea0870711f18810c3/wrapt-2.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:83ce30937f0ba0d28818807b303a412440c4b63e39d3d8fc036a94764b728c92", size = 63240, upload-time = "2025-11-07T00:44:30.935Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/54/5ab4c53ea1f7f7e5c3e7c1095db92932cc32fd62359d285486d00c2884c3/wrapt-2.0.1-cp313-cp313t-win_arm64.whl", hash = "sha256:4b55cacc57e1dc2d0991dbe74c6419ffd415fb66474a02335cb10efd1aa3f84f", size = 60416, upload-time = "2025-11-07T00:44:32.002Z" },
-    { url = "https://files.pythonhosted.org/packages/73/81/d08d83c102709258e7730d3cd25befd114c60e43ef3891d7e6877971c514/wrapt-2.0.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5e53b428f65ece6d9dad23cb87e64506392b720a0b45076c05354d27a13351a1", size = 78290, upload-time = "2025-11-07T00:44:34.691Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/14/393afba2abb65677f313aa680ff0981e829626fed39b6a7e3ec807487790/wrapt-2.0.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ad3ee9d0f254851c71780966eb417ef8e72117155cff04821ab9b60549694a55", size = 61255, upload-time = "2025-11-07T00:44:35.762Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/10/a4a1f2fba205a9462e36e708ba37e5ac95f4987a0f1f8fd23f0bf1fc3b0f/wrapt-2.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7b822c61ed04ee6ad64bc90d13368ad6eb094db54883b5dde2182f67a7f22c0", size = 61797, upload-time = "2025-11-07T00:44:37.22Z" },
-    { url = "https://files.pythonhosted.org/packages/12/db/99ba5c37cf1c4fad35349174f1e38bd8d992340afc1ff27f526729b98986/wrapt-2.0.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7164a55f5e83a9a0b031d3ffab4d4e36bbec42e7025db560f225489fa929e509", size = 120470, upload-time = "2025-11-07T00:44:39.425Z" },
-    { url = "https://files.pythonhosted.org/packages/30/3f/a1c8d2411eb826d695fc3395a431757331582907a0ec59afce8fe8712473/wrapt-2.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e60690ba71a57424c8d9ff28f8d006b7ad7772c22a4af432188572cd7fa004a1", size = 122851, upload-time = "2025-11-07T00:44:40.582Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/8d/72c74a63f201768d6a04a8845c7976f86be6f5ff4d74996c272cefc8dafc/wrapt-2.0.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3cd1a4bd9a7a619922a8557e1318232e7269b5fb69d4ba97b04d20450a6bf970", size = 117433, upload-time = "2025-11-07T00:44:38.313Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5a/df37cf4042cb13b08256f8e27023e2f9b3d471d553376616591bb99bcb31/wrapt-2.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b4c2e3d777e38e913b8ce3a6257af72fb608f86a1df471cb1d4339755d0a807c", size = 121280, upload-time = "2025-11-07T00:44:41.69Z" },
-    { url = "https://files.pythonhosted.org/packages/54/34/40d6bc89349f9931e1186ceb3e5fbd61d307fef814f09fbbac98ada6a0c8/wrapt-2.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3d366aa598d69416b5afedf1faa539fac40c1d80a42f6b236c88c73a3c8f2d41", size = 116343, upload-time = "2025-11-07T00:44:43.013Z" },
-    { url = "https://files.pythonhosted.org/packages/70/66/81c3461adece09d20781dee17c2366fdf0cb8754738b521d221ca056d596/wrapt-2.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c235095d6d090aa903f1db61f892fffb779c1eaeb2a50e566b52001f7a0f66ed", size = 119650, upload-time = "2025-11-07T00:44:44.523Z" },
-    { url = "https://files.pythonhosted.org/packages/46/3a/d0146db8be8761a9e388cc9cc1c312b36d583950ec91696f19bbbb44af5a/wrapt-2.0.1-cp314-cp314-win32.whl", hash = "sha256:bfb5539005259f8127ea9c885bdc231978c06b7a980e63a8a61c8c4c979719d0", size = 58701, upload-time = "2025-11-07T00:44:48.277Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/38/5359da9af7d64554be63e9046164bd4d8ff289a2dd365677d25ba3342c08/wrapt-2.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:4ae879acc449caa9ed43fc36ba08392b9412ee67941748d31d94e3cedb36628c", size = 60947, upload-time = "2025-11-07T00:44:46.086Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3f/96db0619276a833842bf36343685fa04f987dd6e3037f314531a1e00492b/wrapt-2.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:8639b843c9efd84675f1e100ed9e99538ebea7297b62c4b45a7042edb84db03e", size = 59359, upload-time = "2025-11-07T00:44:47.164Z" },
-    { url = "https://files.pythonhosted.org/packages/71/49/5f5d1e867bf2064bf3933bc6cf36ade23505f3902390e175e392173d36a2/wrapt-2.0.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:9219a1d946a9b32bb23ccae66bdb61e35c62773ce7ca6509ceea70f344656b7b", size = 82031, upload-time = "2025-11-07T00:44:49.4Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/89/0009a218d88db66ceb83921e5685e820e2c61b59bbbb1324ba65342668bc/wrapt-2.0.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fa4184e74197af3adad3c889a1af95b53bb0466bced92ea99a0c014e48323eec", size = 62952, upload-time = "2025-11-07T00:44:50.74Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/18/9b968e920dd05d6e44bcc918a046d02afea0fb31b2f1c80ee4020f377cbe/wrapt-2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c5ef2f2b8a53b7caee2f797ef166a390fef73979b15778a4a153e4b5fedce8fa", size = 63688, upload-time = "2025-11-07T00:44:52.248Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/7d/78bdcb75826725885d9ea26c49a03071b10c4c92da93edda612910f150e4/wrapt-2.0.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e042d653a4745be832d5aa190ff80ee4f02c34b21f4b785745eceacd0907b815", size = 152706, upload-time = "2025-11-07T00:44:54.613Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/77/cac1d46f47d32084a703df0d2d29d47e7eb2a7d19fa5cbca0e529ef57659/wrapt-2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2afa23318136709c4b23d87d543b425c399887b4057936cd20386d5b1422b6fa", size = 158866, upload-time = "2025-11-07T00:44:55.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/11/b521406daa2421508903bf8d5e8b929216ec2af04839db31c0a2c525eee0/wrapt-2.0.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6c72328f668cf4c503ffcf9434c2b71fdd624345ced7941bc6693e61bbe36bef", size = 146148, upload-time = "2025-11-07T00:44:53.388Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c0/340b272bed297baa7c9ce0c98ef7017d9c035a17a6a71dce3184b8382da2/wrapt-2.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3793ac154afb0e5b45d1233cb94d354ef7a983708cc3bb12563853b1d8d53747", size = 155737, upload-time = "2025-11-07T00:44:56.971Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/93/bfcb1fb2bdf186e9c2883a4d1ab45ab099c79cbf8f4e70ea453811fa3ea7/wrapt-2.0.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fec0d993ecba3991645b4857837277469c8cc4c554a7e24d064d1ca291cfb81f", size = 144451, upload-time = "2025-11-07T00:44:58.515Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6b/dca504fb18d971139d232652656180e3bd57120e1193d9a5899c3c0b7cdd/wrapt-2.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:949520bccc1fa227274da7d03bf238be15389cd94e32e4297b92337df9b7a349", size = 150353, upload-time = "2025-11-07T00:44:59.753Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f6/a1de4bd3653afdf91d250ca5c721ee51195df2b61a4603d4b373aa804d1d/wrapt-2.0.1-cp314-cp314t-win32.whl", hash = "sha256:be9e84e91d6497ba62594158d3d31ec0486c60055c49179edc51ee43d095f79c", size = 60609, upload-time = "2025-11-07T00:45:03.315Z" },
-    { url = "https://files.pythonhosted.org/packages/01/3a/07cd60a9d26fe73efead61c7830af975dfdba8537632d410462672e4432b/wrapt-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61c4956171c7434634401db448371277d07032a81cc21c599c22953374781395", size = 64038, upload-time = "2025-11-07T00:45:00.948Z" },
-    { url = "https://files.pythonhosted.org/packages/41/99/8a06b8e17dddbf321325ae4eb12465804120f699cd1b8a355718300c62da/wrapt-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:35cdbd478607036fee40273be8ed54a451f5f23121bd9d4be515158f9498f7ad", size = 60634, upload-time = "2025-11-07T00:45:02.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/26/ed6979672ebe0e33f6059fdc8182c4c536e575b6f03d349a542082ca03fb/wrapt-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:90897ea1cf0679763b62e79657958cd54eae5659f6360fc7d2ccc6f906342183", size = 77192, upload-time = "2025-11-07T00:45:04.493Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/a5/fb0974e8d21ef17f75ffa365b395c04eefa23eb6e45548e94c781e93c306/wrapt-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:50844efc8cdf63b2d90cd3d62d4947a28311e6266ce5235a219d21b195b4ec2c", size = 60475, upload-time = "2025-11-07T00:45:05.671Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/7b/56bf38c8bd5e8a48749f1a13c743eddcbd7a616da342b4877f79ec3e7087/wrapt-2.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49989061a9977a8cbd6d20f2efa813f24bf657c6990a42967019ce779a878dbf", size = 61311, upload-time = "2025-11-07T00:45:06.822Z" },
-    { url = "https://files.pythonhosted.org/packages/18/70/ba94af50f2145cb431163d74d405083beb16782818b20c956138e4f59299/wrapt-2.0.1-cp38-cp38-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:09c7476ab884b74dce081ad9bfd07fe5822d8600abade571cb1f66d5fc915af6", size = 118542, upload-time = "2025-11-07T00:45:08.324Z" },
-    { url = "https://files.pythonhosted.org/packages/14/ac/537c8f9cec8a422cfed45b28665ea33344928fd67913e5ff98af0c11470c/wrapt-2.0.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1a8a09a004ef100e614beec82862d11fc17d601092c3599afd22b1f36e4137e", size = 120989, upload-time = "2025-11-07T00:45:09.928Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/b8/463284d8a74e56c88f5f2fb9b572178a294e0beb945b8ee2a7ca43a1696d/wrapt-2.0.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:89a82053b193837bf93c0f8a57ded6e4b6d88033a499dadff5067e912c2a41e9", size = 118937, upload-time = "2025-11-07T00:45:11.157Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/8e/08b8f9de6b3cfd269504b345d31679d283e50cc93cb0521a44475bb7311b/wrapt-2.0.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:f26f8e2ca19564e2e1fdbb6a0e47f36e0efbab1acc31e15471fad88f828c75f6", size = 117150, upload-time = "2025-11-07T00:45:12.324Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f3/0eab878bb4d0eadbec2b75e399cfa6aa802e634587756d59419080aae1f5/wrapt-2.0.1-cp38-cp38-win32.whl", hash = "sha256:115cae4beed3542e37866469a8a1f2b9ec549b4463572b000611e9946b86e6f6", size = 57936, upload-time = "2025-11-07T00:45:15.468Z" },
-    { url = "https://files.pythonhosted.org/packages/03/e5/fc964b370bf568312deda176682138ccbd41960285a7de49002183e2aa08/wrapt-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:c4012a2bd37059d04f8209916aa771dfb564cccb86079072bdcd48a308b6a5c5", size = 60308, upload-time = "2025-11-07T00:45:13.573Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/1f/5af0ae22368ec69067a577f9e07a0dd2619a1f63aabc2851263679942667/wrapt-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:68424221a2dc00d634b54f92441914929c5ffb1c30b3b837343978343a3512a3", size = 77478, upload-time = "2025-11-07T00:45:16.65Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/b7/fd6b563aada859baabc55db6aa71b8afb4a3ceb8bc33d1053e4c7b5e0109/wrapt-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6bd1a18f5a797fe740cb3d7a0e853a8ce6461cc62023b630caec80171a6b8097", size = 60687, upload-time = "2025-11-07T00:45:17.896Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/8c/9ededfff478af396bcd081076986904bdca336d9664d247094150c877dcb/wrapt-2.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fb3a86e703868561c5cad155a15c36c716e1ab513b7065bd2ac8ed353c503333", size = 61563, upload-time = "2025-11-07T00:45:19.109Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a7/d795a1aa2b6ab20ca21157fe03cbfc6aa7e870a88ac3b4ea189e2f6c79f0/wrapt-2.0.1-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5dc1b852337c6792aa111ca8becff5bacf576bf4a0255b0f05eb749da6a1643e", size = 113395, upload-time = "2025-11-07T00:45:21.551Z" },
-    { url = "https://files.pythonhosted.org/packages/61/32/56cde2bbf95f2d5698a1850a765520aa86bc7ae0f95b8ec80b6f2e2049bb/wrapt-2.0.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c046781d422f0830de6329fa4b16796096f28a92c8aef3850674442cdcb87b7f", size = 115362, upload-time = "2025-11-07T00:45:22.809Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/53/8d3cc433847c219212c133a3e8305bd087b386ef44442ff39189e8fa62ac/wrapt-2.0.1-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f73f9f7a0ebd0db139253d27e5fc8d2866ceaeef19c30ab5d69dcbe35e1a6981", size = 111766, upload-time = "2025-11-07T00:45:20.294Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d3/14b50c2d0463c0dcef8f388cb1527ed7bbdf0972b9fd9976905f36c77ebf/wrapt-2.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b667189cf8efe008f55bbda321890bef628a67ab4147ebf90d182f2dadc78790", size = 114560, upload-time = "2025-11-07T00:45:24.054Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/b8/4f731ff178f77ae55385586de9ff4b4261e872cf2ced4875e6c976fbcb8b/wrapt-2.0.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:a9a83618c4f0757557c077ef71d708ddd9847ed66b7cc63416632af70d3e2308", size = 110999, upload-time = "2025-11-07T00:45:25.596Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/bb/5f1bb0f9ae9d12e19f1d71993d052082062603e83fe3e978377f918f054d/wrapt-2.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1e9b121e9aeb15df416c2c960b8255a49d44b4038016ee17af03975992d03931", size = 113164, upload-time = "2025-11-07T00:45:26.8Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/f6/f3a3c623d3065c7bf292ee0b73566236b562d5ed894891bd8e435762b618/wrapt-2.0.1-cp39-cp39-win32.whl", hash = "sha256:1f186e26ea0a55f809f232e92cc8556a0977e00183c3ebda039a807a42be1494", size = 58028, upload-time = "2025-11-07T00:45:30.943Z" },
-    { url = "https://files.pythonhosted.org/packages/24/78/647c609dfa18063a7fcd5c23f762dd006be401cc9206314d29c9b0b12078/wrapt-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:bf4cb76f36be5de950ce13e22e7fdf462b35b04665a12b64f3ac5c1bbbcf3728", size = 60380, upload-time = "2025-11-07T00:45:28.341Z" },
-    { url = "https://files.pythonhosted.org/packages/07/90/0c14b241d18d80ddf4c847a5f52071e126e8a6a9e5a8a7952add8ef0d766/wrapt-2.0.1-cp39-cp39-win_arm64.whl", hash = "sha256:d6cc985b9c8b235bd933990cdbf0f891f8e010b65a3911f7a55179cd7b0fc57b", size = 58895, upload-time = "2025-11-07T00:45:29.527Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
-]
-
-[[package]]
-name = "wrapt"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/37/ae31f40bec90de2f88d9597d0b5281e23ffe85b893a47ca5d9c05c63a4f6/wrapt-2.1.1.tar.gz", hash = "sha256:5fdcb09bf6db023d88f312bd0767594b414655d58090fc1c46b3414415f67fac", size = 81329, upload-time = "2026-02-03T02:12:13.786Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/21/293b657a27accfbbbb6007ebd78af0efa2083dac83e8f523272ea09b4638/wrapt-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7e927375e43fd5a985b27a8992327c22541b6dede1362fc79df337d26e23604f", size = 60554, upload-time = "2026-02-03T02:11:17.362Z" },
@@ -2389,24 +1631,8 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "3.20.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199, upload-time = "2024-09-13T13:44:16.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200, upload-time = "2024-09-13T13:44:14.38Z" },
-]
-
-[[package]]
-name = "zipp"
 version = "3.23.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },


### PR DESCRIPTION
<!--- Copyright (c) 2024 Benjamin Mummery -->

## Problem Statement

Adds a new hook that syncs type hints between the docstring and function signature.

## Checklist

- [x] The PR title follows semantic release rules (starts with one of `build`, `chore`, `ci`, `docs`, `feat`,`fix`, `perf`, `style`, `refactor`, `test`). Note that this is CASE SENSITIVE!
- [x] All commits in this PR follow semantic release rules.
